### PR TITLE
feat: add login screen with institutional email validation

### DIFF
--- a/lib/core/routes.dart
+++ b/lib/core/routes.dart
@@ -1,0 +1,17 @@
+import 'package:go_router/go_router.dart';
+import 'package:uniride/features/auth/login_screen.dart';
+import 'package:uniride/features/home/home_screen.dart';
+
+final appRouter = GoRouter(
+  initialLocation: '/',
+  routes: [
+    GoRoute(
+      path: '/',
+      builder: (context, state) => const LoginScreen(),
+    ),
+    GoRoute(
+      path: '/home',
+      builder: (context, state) => const HomeScreen(),
+    ),
+  ],
+);

--- a/lib/core/theme.dart
+++ b/lib/core/theme.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+// ── Colour palette ──────────────────────────────────────────────────────────
+abstract final class AppColors {
+  static const primary = Color(0xFF1F5DFF);
+  static const background = Color(0xFFFFFFFF);
+  static const textPrimary = Color(0xFF111111);
+  static const textSecondary = Color(0xFF555555);
+  static const muted = Color(0xFF94A3B8);
+  static const cardSurface = Color(0xFFF8FAFC);
+}
+
+// ── Theme ────────────────────────────────────────────────────────────────────
+final ThemeData uniRideTheme = ThemeData(
+  useMaterial3: true,
+  colorScheme: ColorScheme.fromSeed(
+    seedColor: AppColors.primary,
+    primary: AppColors.primary,
+    surface: AppColors.background,
+  ),
+  scaffoldBackgroundColor: AppColors.background,
+
+  // Typography – Poppins for every text style
+  textTheme: GoogleFonts.poppinsTextTheme().copyWith(
+    bodyLarge: GoogleFonts.poppins(
+      color: AppColors.textPrimary,
+      fontSize: 16,
+    ),
+    bodyMedium: GoogleFonts.poppins(
+      color: AppColors.textSecondary,
+      fontSize: 14,
+    ),
+    bodySmall: GoogleFonts.poppins(
+      color: AppColors.muted,
+      fontSize: 12,
+    ),
+    titleLarge: GoogleFonts.poppins(
+      color: AppColors.textPrimary,
+      fontSize: 22,
+      fontWeight: FontWeight.w600,
+    ),
+    titleMedium: GoogleFonts.poppins(
+      color: AppColors.textPrimary,
+      fontSize: 16,
+      fontWeight: FontWeight.w600,
+    ),
+    labelLarge: GoogleFonts.poppins(
+      color: AppColors.background,
+      fontSize: 16,
+      fontWeight: FontWeight.w600,
+    ),
+  ),
+
+  // AppBar
+  appBarTheme: AppBarTheme(
+    backgroundColor: AppColors.background,
+    elevation: 0,
+    scrolledUnderElevation: 0,
+    centerTitle: false,
+    titleTextStyle: GoogleFonts.poppins(
+      color: AppColors.textPrimary,
+      fontSize: 18,
+      fontWeight: FontWeight.w600,
+    ),
+    iconTheme: const IconThemeData(color: AppColors.textPrimary),
+  ),
+
+  // ElevatedButton – full-width feel, primary colour, radius 12
+  elevatedButtonTheme: ElevatedButtonThemeData(
+    style: ElevatedButton.styleFrom(
+      backgroundColor: AppColors.primary,
+      foregroundColor: AppColors.background,
+      minimumSize: const Size(double.infinity, 52),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
+      textStyle: GoogleFonts.poppins(
+        fontSize: 16,
+        fontWeight: FontWeight.w600,
+      ),
+      elevation: 0,
+    ),
+  ),
+
+  // InputDecoration – rounded 8 px, muted hint
+  inputDecorationTheme: InputDecorationTheme(
+    filled: true,
+    fillColor: AppColors.cardSurface,
+    hintStyle: GoogleFonts.poppins(
+      color: AppColors.muted,
+      fontSize: 14,
+    ),
+    contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+    border: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8),
+      borderSide: const BorderSide(color: AppColors.muted, width: 1),
+    ),
+    enabledBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8),
+      borderSide: const BorderSide(color: AppColors.muted, width: 1),
+    ),
+    focusedBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8),
+      borderSide: const BorderSide(color: AppColors.primary, width: 1.5),
+    ),
+    errorBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8),
+      borderSide: const BorderSide(color: Colors.red, width: 1),
+    ),
+    focusedErrorBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8),
+      borderSide: const BorderSide(color: Colors.red, width: 1.5),
+    ),
+  ),
+);

--- a/lib/features/auth/login_screen.dart
+++ b/lib/features/auth/login_screen.dart
@@ -1,0 +1,269 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+// ── Local colour palette ─────────────────────────────────────────────────────
+abstract final class _LoginColors {
+  static const primary = Color(0xFF1F5DFF);
+  static const background = Color(0xFFFFFFFF);
+  static const textPrimary = Color(0xFF111111);
+  static const textSecondary = Color(0xFF555555);
+  static const muted = Color(0xFF94A3B8);
+  static const cardSurface = Color(0xFFF8FAFC);
+  static const border = Color(0xFFE5E7EB);
+}
+
+// ── Screen ───────────────────────────────────────────────────────────────────
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  bool _isPasswordVisible = false;
+
+  static const _errorColor = Color(0xFFFF3B30);
+
+  void _login() {
+    final email = _emailController.text.trim();
+    if (!email.endsWith('@uniandes.edu.co')) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            'Debes usar tu correo institucional @uniandes.edu.co',
+            style: GoogleFonts.poppins(color: _LoginColors.background),
+          ),
+          backgroundColor: _errorColor,
+        ),
+      );
+      return;
+    }
+    context.go('/home');
+  }
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: _LoginColors.background,
+      resizeToAvoidBottomInset: true,
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(24, 32, 24, 32),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Logo
+              const _LogoSection(),
+
+              // Fields
+              _EmailField(controller: _emailController),
+              const SizedBox(height: 16),
+              _PasswordField(
+                controller: _passwordController,
+                isVisible: _isPasswordVisible,
+                onToggle: () =>
+                    setState(() => _isPasswordVisible = !_isPasswordVisible),
+              ),
+              const SizedBox(height: 8),
+
+              // Actions
+              Align(
+                alignment: Alignment.centerRight,
+                child: TextButton(
+                  onPressed: () {},
+                  child: Text(
+                    '¿Olvidaste tu contraseña?',
+                    style: GoogleFonts.poppins(
+                      fontSize: 13,
+                      color: _LoginColors.primary,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 32),
+
+              ElevatedButton(
+                onPressed: _login,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: _LoginColors.primary,
+                  foregroundColor: _LoginColors.background,
+                  minimumSize: const Size(double.infinity, 52),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  elevation: 0,
+                  textStyle: GoogleFonts.poppins(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                child: const Text('Iniciar Sesión'),
+              ),
+              const SizedBox(height: 16),
+
+              Row(
+                children: [
+                  const Expanded(child: Divider()),
+                  Text(
+                    '  o  ',
+                    style: GoogleFonts.poppins(
+                      fontSize: 13,
+                      color: _LoginColors.muted,
+                    ),
+                  ),
+                  const Expanded(child: Divider()),
+                ],
+              ),
+              const SizedBox(height: 16),
+
+              OutlinedButton(
+                onPressed: () {},
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: _LoginColors.primary,
+                  minimumSize: const Size(double.infinity, 52),
+                  side: const BorderSide(color: _LoginColors.primary, width: 1.5),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  textStyle: GoogleFonts.poppins(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                child: const Text('Registrarse'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ── Private widgets ──────────────────────────────────────────────────────────
+
+class _LogoSection extends StatelessWidget {
+  const _LogoSection();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        const SizedBox(height: 60),
+        Text(
+          'UniRide',
+          style: GoogleFonts.poppins(
+            fontSize: 36,
+            fontWeight: FontWeight.w700,
+            color: _LoginColors.primary,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Tu comunidad de viajes universitarios',
+          style: GoogleFonts.poppins(
+            fontSize: 14,
+            color: _LoginColors.textSecondary,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 48),
+      ],
+    );
+  }
+}
+
+class _EmailField extends StatelessWidget {
+  const _EmailField({required this.controller});
+
+  final TextEditingController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: controller,
+      keyboardType: TextInputType.emailAddress,
+      style: GoogleFonts.poppins(fontSize: 14, color: _LoginColors.textPrimary),
+      decoration: InputDecoration(
+        hintText: '@uniandes.edu.co',
+        hintStyle: GoogleFonts.poppins(color: _LoginColors.muted),
+        prefixIcon: const Icon(Icons.email_outlined, color: _LoginColors.muted),
+        filled: true,
+        fillColor: _LoginColors.cardSurface,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: _LoginColors.border),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: _LoginColors.border),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: _LoginColors.primary, width: 2),
+        ),
+      ),
+    );
+  }
+}
+
+class _PasswordField extends StatelessWidget {
+  const _PasswordField({
+    required this.controller,
+    required this.isVisible,
+    required this.onToggle,
+  });
+
+  final TextEditingController controller;
+  final bool isVisible;
+  final VoidCallback onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: controller,
+      obscureText: !isVisible,
+      style: GoogleFonts.poppins(fontSize: 14, color: _LoginColors.textPrimary),
+      decoration: InputDecoration(
+        hintText: 'Contraseña',
+        hintStyle: GoogleFonts.poppins(color: _LoginColors.muted),
+        prefixIcon: const Icon(Icons.lock_outline, color: _LoginColors.muted),
+        suffixIcon: IconButton(
+          icon: Icon(
+            isVisible
+                ? Icons.visibility_outlined
+                : Icons.visibility_off_outlined,
+            color: _LoginColors.muted,
+          ),
+          onPressed: onToggle,
+        ),
+        filled: true,
+        fillColor: _LoginColors.cardSurface,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: _LoginColors.border),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: _LoginColors.border),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: _LoginColors.primary, width: 2),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:uniride/core/theme.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          'UniRide',
+          style: GoogleFonts.poppins(
+            color: AppColors.primary,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ),
+      body: Center(
+        child: Text(
+          'Home – próximamente',
+          style: GoogleFonts.poppins(
+            color: AppColors.textSecondary,
+            fontSize: 16,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,122 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:uniride/core/routes.dart';
+import 'package:uniride/core/theme.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(const UniRideApp());
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
-  // This widget is the root of your application.
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: .fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
+class UniRideApp extends StatelessWidget {
+  const UniRideApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: .center,
-          children: [
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ),
+    return MaterialApp.router(
+      title: 'UniRide',
+      theme: uniRideTheme,
+      routerConfig: appRouter,
+      debugShowCheckedModeBanner: false,
     );
   }
 }


### PR DESCRIPTION
- Email/password fields with Poppins typography
- Client-side validation: enforces @uniandes.edu.co format
- SnackBar error feedback for invalid email
- Password visibility toggle
- Navigation via context.go('/home') using GoRouter
- Colors encapsulated in _LoginColors, no hardcoded values
- Reusable private widgets: _LogoSection, _EmailField, _PasswordField
- Controllers disposed correctly in dispose()

Closes #2