### PR TITLE
Sprint 3 — Local Storage, Caching, Connectivity & Concurrency strategies on HomeScreen

### DIFF
--- a/lib/core/cache/lru_cache.dart
+++ b/lib/core/cache/lru_cache.dart
@@ -1,0 +1,30 @@
+import 'dart:collection';
+
+/// Thread-safe by design: Dart isolates are
+/// single-threaded, no mutex needed.
+/// Capacity 50 covers ~5-10 origin/destination
+/// combinations per session (~100KB max).
+class LRUCache<K, V> {
+  LRUCache({this.capacity = 50});
+
+  final int capacity;
+  final LinkedHashMap<K, V> _map = LinkedHashMap();
+
+  V? get(K key) {
+    if (!_map.containsKey(key)) return null;
+    final value = _map.remove(key) as V;
+    _map[key] = value;
+    return value;
+  }
+
+  void put(K key, V value) {
+    if (_map.length >= capacity) {
+      _map.remove(_map.keys.first);
+    }
+    _map[key] = value;
+  }
+
+  void invalidate(K key) => _map.remove(key);
+  void invalidateAll() => _map.clear();
+  int get size => _map.length;
+}

--- a/lib/core/connectivity/connectivity_service.dart
+++ b/lib/core/connectivity/connectivity_service.dart
@@ -1,0 +1,18 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+class ConnectivityService {
+  ConnectivityService._internal();
+  static final ConnectivityService instance = ConnectivityService._internal();
+  factory ConnectivityService() => instance;
+
+  final Connectivity _connectivity = Connectivity();
+
+  Stream<bool> get onStatusChanged => _connectivity.onConnectivityChanged.map(
+        (results) => results.any((r) => r != ConnectivityResult.none),
+      );
+
+  Future<bool> isOnline() async {
+    final results = await _connectivity.checkConnectivity();
+    return results.any((r) => r != ConnectivityResult.none);
+  }
+}

--- a/lib/core/db/daos/ride_dao.dart
+++ b/lib/core/db/daos/ride_dao.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:sqflite/sqflite.dart';
 
 import '../../../data/models/ride_model.dart';
@@ -37,5 +38,29 @@ class RideDao {
   Future<void> deleteAll() async {
     final db = await _helper.database;
     await db.delete('rides');
+  }
+
+  Future<void> deleteExpiredRides() async {
+    final db = await _helper.database;
+    final nowMs = DateTime.now().millisecondsSinceEpoch;
+    final deleted = await db.delete(
+      'rides',
+      where: 'departure_time < ?',
+      whereArgs: [nowMs],
+    );
+    debugPrint('[SQLite] deleted $deleted expired rides');
+  }
+
+  Future<void> deleteStaleRides({
+    Duration maxAge = const Duration(hours: 6),
+  }) async {
+    final db = await _helper.database;
+    final cutoff = DateTime.now().subtract(maxAge).millisecondsSinceEpoch;
+    final deleted = await db.delete(
+      'rides',
+      where: 'cached_at < ?',
+      whereArgs: [cutoff],
+    );
+    debugPrint('[SQLite] deleted $deleted stale rides');
   }
 }

--- a/lib/core/db/daos/ride_dao.dart
+++ b/lib/core/db/daos/ride_dao.dart
@@ -1,0 +1,41 @@
+import 'package:sqflite/sqflite.dart';
+
+import '../../../data/models/ride_model.dart';
+import '../database_helper.dart';
+import '../entities/ride_entity.dart';
+
+class RideDao {
+  RideDao(this._helper);
+
+  final DatabaseHelper _helper;
+
+  Future<void> insertOrReplaceAll(List<RideModel> rides) async {
+    final db = await _helper.database;
+    final batch = db.batch();
+    for (final ride in rides) {
+      batch.insert(
+        'rides',
+        ride.toDbMap(),
+        conflictAlgorithm: ConflictAlgorithm.replace,
+      );
+    }
+    await batch.commit(noResult: true);
+  }
+
+  Future<List<RideModel>> fetchAll() async {
+    final db = await _helper.database;
+    final rows = await db.query('rides');
+    return rows.map((row) => RideEntityExtension.fromDbMap(row)).toList();
+  }
+
+  Future<int> count() async {
+    final db = await _helper.database;
+    final result = await db.rawQuery('SELECT COUNT(*) as c FROM rides');
+    return (result.first['c'] as int?) ?? 0;
+  }
+
+  Future<void> deleteAll() async {
+    final db = await _helper.database;
+    await db.delete('rides');
+  }
+}

--- a/lib/core/db/database_helper.dart
+++ b/lib/core/db/database_helper.dart
@@ -1,0 +1,54 @@
+import 'package:path/path.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:sqflite/sqflite.dart';
+
+class DatabaseHelper {
+  DatabaseHelper._internal();
+  static final DatabaseHelper _instance = DatabaseHelper._internal();
+  factory DatabaseHelper() => _instance;
+
+  Database? _database;
+
+  Future<Database> get database async {
+    _database ??= await _initDatabase();
+    return _database!;
+  }
+
+  Future<Database> _initDatabase() async {
+    final dir = await getApplicationDocumentsDirectory();
+    final path = join(dir.path, 'uniride.db');
+    return openDatabase(
+      path,
+      version: 1,
+      onCreate: _onCreate,
+      onUpgrade: _onUpgrade,
+    );
+  }
+
+  Future<void> _onCreate(Database db, int version) async {
+    await db.execute('''
+      CREATE TABLE rides (
+        id TEXT PRIMARY KEY,
+        driver_id TEXT NOT NULL,
+        driver_name TEXT NOT NULL,
+        driver_rating REAL NOT NULL,
+        driver_gender TEXT NOT NULL DEFAULT 'male',
+        origin TEXT NOT NULL,
+        destination TEXT NOT NULL,
+        zone TEXT NOT NULL DEFAULT '',
+        departure_time INTEGER NOT NULL,
+        seats_available INTEGER NOT NULL,
+        status TEXT NOT NULL DEFAULT 'available',
+        price REAL NOT NULL,
+        punctuality_rate REAL NOT NULL DEFAULT 0.0,
+        cached_at INTEGER NOT NULL
+      )
+    ''');
+    await db.execute('CREATE INDEX idx_rides_zone ON rides(zone)');
+    await db.execute('CREATE INDEX idx_rides_status ON rides(status)');
+  }
+
+  Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
+    // TODO: add future migrations here
+  }
+}

--- a/lib/core/db/entities/ride_entity.dart
+++ b/lib/core/db/entities/ride_entity.dart
@@ -1,0 +1,45 @@
+import '../../../data/models/ride_model.dart';
+
+extension RideEntityExtension on RideModel {
+  Map<String, dynamic> toDbMap() {
+    return {
+      'id': id,
+      'driver_id': driverId,
+      'driver_name': driverName,
+      'driver_rating': driverRating,
+      'driver_gender': gender,
+      'origin': origin,
+      'destination': destination,
+      'zone': zone,
+      'departure_time': departureTime.millisecondsSinceEpoch,
+      'seats_available': seatsAvailable,
+      'status': status,
+      'price': price,
+      'punctuality_rate': punctualityRate,
+      'cached_at': DateTime.now().millisecondsSinceEpoch,
+    };
+  }
+
+  static RideModel fromDbMap(Map<String, dynamic> m) {
+    final gender = (m['driver_gender'] as String?) ?? 'male';
+    return RideModel(
+      id: m['id'] as String,
+      driverId: m['driver_id'] as String,
+      driverName: m['driver_name'] as String,
+      driverRating: (m['driver_rating'] as num).toDouble(),
+      origin: m['origin'] as String,
+      destination: m['destination'] as String,
+      departureTime:
+          DateTime.fromMillisecondsSinceEpoch(m['departure_time'] as int),
+      price: (m['price'] as num).toDouble(),
+      seatsAvailable: m['seats_available'] as int,
+      status: m['status'] as String,
+      zone: (m['zone'] as String?) ?? '',
+      gender: gender,
+      isFemaleDriver: gender.toLowerCase() == 'female',
+      punctualityRate:
+          ((m['punctuality_rate'] as num?)?.toDouble()) ?? 0.0,
+      hasRainForecast: false,
+    );
+  }
+}

--- a/lib/data/repositories/impl/firebase_ride_repository.dart
+++ b/lib/data/repositories/impl/firebase_ride_repository.dart
@@ -234,7 +234,7 @@ class FirebaseRideRepository implements RideRepository {
       final cached = _lruCache.get(key);
       if (cached != null) {
         debugPrint('[LRU] hit — ${cached.length} rides');
-        onCacheStatus?.call(true);
+        onCacheStatus?.call(false); // LRU = RAM, fresh session data, no banner
         return cached;
       }
     }

--- a/lib/data/repositories/impl/firebase_ride_repository.dart
+++ b/lib/data/repositories/impl/firebase_ride_repository.dart
@@ -227,6 +227,7 @@ class FirebaseRideRepository implements RideRepository {
     bool forceRefresh = false,
     void Function(bool isFromCache)? onCacheStatus,
   }) async {
+    unawaited(_dao.deleteExpiredRides());
     const key = 'available_rides';
 
     if (!forceRefresh) {

--- a/lib/data/repositories/impl/firebase_ride_repository.dart
+++ b/lib/data/repositories/impl/firebase_ride_repository.dart
@@ -1,5 +1,11 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
+import 'dart:async';
 
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../../core/cache/lru_cache.dart';
+import '../../../core/db/daos/ride_dao.dart';
+import '../../../core/db/database_helper.dart';
 import '../../models/ride_details_model.dart';
 import '../../models/ride_model.dart';
 import '../ride_repository.dart';
@@ -7,9 +13,13 @@ import '../ride_repository.dart';
 class FirebaseRideRepository implements RideRepository {
   FirebaseRideRepository({
     FirebaseFirestore? firestore,
-  }) : _firestore = firestore ?? FirebaseFirestore.instance;
+  }) : _firestore = firestore ?? FirebaseFirestore.instance {
+    _dao = RideDao(DatabaseHelper());
+  }
 
   final FirebaseFirestore _firestore;
+  final LRUCache<String, List<RideModel>> _lruCache = LRUCache(capacity: 50);
+  late final RideDao _dao;
 
   @override
   Future<List<RideModel>> getAvailableRides() async {
@@ -211,6 +221,45 @@ class FirebaseRideRepository implements RideRepository {
         });
       }
     });
+  }
+
+  Future<List<RideModel>> getAvailableRidesWithFallback({
+    bool forceRefresh = false,
+    void Function(bool isFromCache)? onCacheStatus,
+  }) async {
+    const key = 'available_rides';
+
+    if (!forceRefresh) {
+      final cached = _lruCache.get(key);
+      if (cached != null) {
+        debugPrint('[LRU] hit — ${cached.length} rides');
+        onCacheStatus?.call(true);
+        return cached;
+      }
+    }
+
+    try {
+      final rides = await getAvailableRides();
+      _lruCache.put(key, rides);
+      unawaited(_dao.insertOrReplaceAll(rides));
+      debugPrint('[Repo] Firestore ok — ${rides.length}');
+      onCacheStatus?.call(false);
+      return rides;
+    } catch (e) {
+      debugPrint('[Repo] Firestore failed: $e');
+      final local = await _dao.fetchAll();
+      if (local.isNotEmpty) {
+        _lruCache.put(key, local);
+        debugPrint('[SQLite] fallback — ${local.length}');
+        onCacheStatus?.call(true);
+        return local;
+      }
+      rethrow;
+    }
+  }
+
+  void invalidateRideCache() {
+    _lruCache.invalidateAll();
   }
 
   String _normalizeDriverId(String raw) {

--- a/lib/data/repositories/impl/open_meteo_repository.dart
+++ b/lib/data/repositories/impl/open_meteo_repository.dart
@@ -16,37 +16,37 @@ class OpenMeteoRepository implements WeatherRepository {
 
   @override
   Future<WeatherData> getCurrentWeather() async {
-    try {
-      final response = await http.get(Uri.parse(_url));
-      if (response.statusCode != 200) return WeatherData.defaultData;
-
-      final json = jsonDecode(response.body) as Map<String, dynamic>;
-      final currentWeather = json['current_weather'] as Map<String, dynamic>;
-      final hourly = json['hourly'] as Map<String, dynamic>;
-
-      final temperature =
-          (currentWeather['temperature'] as num).toDouble();
-      final weatherCode =
-          (currentWeather['weathercode'] as num).toInt();
-
-      // Fix 1 — Null-safe precipitation parsing
-      final rawList = (hourly['precipitation_probability'] as List?) ?? [];
-      final precipList =
-          rawList.map((v) => v == null ? 0 : (v as num).toInt()).toList();
-
-      // Precipitation probability for the next hour only
-      final maxPrecip = precipList.isEmpty ? 0 : precipList.first;
-
-      return WeatherData(
-        temperature: temperature,
-        description: _descriptionFromCode(weatherCode),
-        precipitationProbability: maxPrecip,
-        willRainSoon: maxPrecip >= 10,
-        weatherCode: weatherCode,
-      );
-    } catch (_) {
-      return WeatherData.defaultData;
+    final response = await http.get(Uri.parse(_url));
+    if (response.statusCode != 200) {
+      throw Exception('Weather API error: ${response.statusCode}');
     }
+
+    final json = jsonDecode(response.body) as Map<String, dynamic>;
+    final currentWeather = json['current_weather'] as Map<String, dynamic>;
+    final hourly = json['hourly'] as Map<String, dynamic>;
+
+    final temperature = (currentWeather['temperature'] as num).toDouble();
+    final weatherCode = (currentWeather['weathercode'] as num).toInt();
+
+    final rawList = (hourly['precipitation_probability'] as List?) ?? [];
+    final precipList =
+        rawList.map((v) => v == null ? 0 : (v as num).toInt()).toList();
+    final maxPrecip = precipList.isEmpty ? 0 : precipList.first;
+
+    return WeatherData(
+      temperature: temperature,
+      description: _descriptionFromCode(weatherCode),
+      precipitationProbability: maxPrecip,
+      willRainSoon: maxPrecip >= 10,
+      weatherCode: weatherCode,
+    );
+  }
+
+  void fetchCurrentWithCallback({
+    required void Function(WeatherData) onSuccess,
+    required void Function(Object) onError,
+  }) {
+    getCurrentWeather().then(onSuccess).catchError(onError);
   }
 
   static String _descriptionFromCode(int code) {

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -90,10 +90,11 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   void initState() {
     super.initState();
-    unawaited(RideDao(DatabaseHelper()).deleteExpiredRides());
-    unawaited(RideDao(DatabaseHelper()).deleteStaleRides(maxAge: const Duration(hours: 6)));
-    context.read<RideViewModel>().loadAvailableRides();
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(RideDao(DatabaseHelper()).deleteExpiredRides());
+      unawaited(RideDao(DatabaseHelper()).deleteStaleRides(
+          maxAge: const Duration(hours: 6)));
+      context.read<RideViewModel>().loadAvailableRides();
       context.read<WeatherViewModel>().loadWeather();
       context.read<AuthViewModel>().loadRecurringRoutes();
     });

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -8,6 +8,8 @@ import 'package:provider/provider.dart';
 import 'package:uniride/shared/widgets/bottom_nav_bar.dart';
 import 'package:uniride/shared/widgets/location_disabled_banner.dart';
 
+import '../../core/db/daos/ride_dao.dart';
+import '../../core/db/database_helper.dart';
 import '../../core/location_utils.dart';
 import '../../data/models/ride_model.dart';
 import '../../features/auth/auth_viewmodel.dart';
@@ -88,6 +90,8 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   void initState() {
     super.initState();
+    unawaited(RideDao(DatabaseHelper()).deleteExpiredRides());
+    unawaited(RideDao(DatabaseHelper()).deleteStaleRides(maxAge: const Duration(hours: 6)));
     context.read<RideViewModel>().loadAvailableRides();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       context.read<WeatherViewModel>().loadWeather();

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -9,10 +9,12 @@ import 'package:uniride/shared/widgets/bottom_nav_bar.dart';
 import 'package:uniride/shared/widgets/location_disabled_banner.dart';
 import 'package:uniride/shared/widgets/offline_banner.dart';
 
+import '../../core/connectivity/connectivity_service.dart';
 import '../../core/db/daos/ride_dao.dart';
 import '../../core/db/database_helper.dart';
 import '../../core/location_utils.dart';
 import '../../data/models/ride_model.dart';
+import '../../data/models/weather_model.dart';
 import '../../features/auth/auth_viewmodel.dart';
 import '../../features/home/weather_viewmodel.dart';
 import '../../features/rides/ride_viewmodel.dart';
@@ -97,6 +99,7 @@ class _HomeScreenState extends State<HomeScreen> {
           maxAge: const Duration(hours: 6)));
       context.read<RideViewModel>().loadAvailableRides();
       context.read<WeatherViewModel>().loadWeather();
+      context.read<WeatherViewModel>().startAutoRefresh();
       context.read<AuthViewModel>().loadRecurringRoutes();
     });
   }
@@ -138,20 +141,19 @@ class _HomeScreenState extends State<HomeScreen> {
         ),
       ),
       bottomNavigationBar: const UniRideBottomNav(currentIndex: 0),
-      body: Column(
-        children: [
-          Consumer<RideViewModel>(
-            builder: (_, vm, _) => OfflineBanner(
-              isOffline: vm.isOffline,
-              isFromCache: vm.isFromCache,
-            ),
-          ),
-          Expanded(
-            child: SafeArea(
-              child: SingleChildScrollView(
+      body: SafeArea(
+        child: SingleChildScrollView(
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              // Offline / cache banner — inside SafeArea so it clears the status bar
+              Consumer<RideViewModel>(
+                builder: (_, vm, _) => OfflineBanner(
+                  isOffline: vm.isOffline,
+                  isFromCache: vm.isFromCache,
+                ),
+              ),
+
               // Header
               _HomeHeader(firstName: firstName, initial: initial),
               const SizedBox(height: 8),
@@ -236,9 +238,6 @@ class _HomeScreenState extends State<HomeScreen> {
             ],
           ),
         ),
-      ),
-          ),
-        ],
       ),
     );
   }
@@ -419,6 +418,8 @@ class _SearchCardState extends State<_SearchCard> {
   bool _gpsAutoFilled = false;
   bool _locationServiceDisabled = false;
   StreamSubscription<ServiceStatus>? _locationServiceStream;
+  StreamSubscription<bool>? _connectivitySub;
+  Timer? _locationRefreshTimer;
 
   static const _timeOptions = ['Now', 'In 30 min', 'In 1 hour', 'In 2 hours'];
 
@@ -429,6 +430,8 @@ class _SearchCardState extends State<_SearchCard> {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (!mounted) return;
       await _tryAutoFillLocation();
+
+      // Re-trigger GPS when GPS service toggles
       _locationServiceStream = Geolocator.getServiceStatusStream().listen(
         (ServiceStatus status) {
           if (!mounted) return;
@@ -440,6 +443,22 @@ class _SearchCardState extends State<_SearchCard> {
           }
         },
       );
+
+      // Re-trigger GPS when network comes back (airplane mode fix)
+      _connectivitySub = ConnectivityService().onStatusChanged.listen((isOnline) {
+        if (isOnline && mounted) {
+          debugPrint('[GPS] connectivity restored — retrying location');
+          _tryAutoFillLocation();
+        }
+      });
+
+      // Refresh location every 5 minutes while on this screen
+      _locationRefreshTimer = Timer.periodic(const Duration(minutes: 5), (_) {
+        if (mounted) {
+          debugPrint('[GPS] periodic refresh triggered');
+          _tryAutoFillLocation();
+        }
+      });
     });
   }
 
@@ -448,7 +467,8 @@ class _SearchCardState extends State<_SearchCard> {
   }
 
   Future<void> _tryAutoFillLocation() async {
-    if (_fromController.text.isNotEmpty) return;
+    // Allow fill if field is empty OR was GPS-filled (not manually typed)
+    if (_fromController.text.isNotEmpty && !_gpsAutoFilled) return;
     final bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
     if (!serviceEnabled) {
       if (mounted) setState(() => _locationServiceDisabled = true);
@@ -456,15 +476,18 @@ class _SearchCardState extends State<_SearchCard> {
     }
     if (mounted) setState(() => _locationServiceDisabled = false);
     final zone = await LocationUtils.detectZone();
-    if (zone != null && mounted && _fromController.text.isEmpty) {
+    if (zone != null && mounted) {
       _fromController.text = zone;
       setState(() => _gpsAutoFilled = true);
+      debugPrint('[GPS] auto-filled: $zone');
     }
   }
 
   @override
   void dispose() {
     _locationServiceStream?.cancel();
+    _connectivitySub?.cancel();
+    _locationRefreshTimer?.cancel();
     _fromController.removeListener(_onFromChanged);
     _fromController.dispose();
     _toController.dispose();
@@ -836,69 +859,70 @@ class _WeatherChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final weather = context.watch<WeatherViewModel>().weather;
+    return StreamBuilder<WeatherData>(
+      stream: context.read<WeatherViewModel>().weatherStream,
+      initialData: context.read<WeatherViewModel>().weather,
+      builder: (context, snapshot) {
+        final weather = snapshot.data;
 
-    // Manejo de estado cuando el clima aún no carga
-    if (weather == null) {
-      return Container(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-        decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.circular(16),
-          boxShadow: const [BoxShadow(color: Colors.black12, blurRadius: 4)],
-        ),
-        child: const Text('--', style: TextStyle(fontSize: 11)),
-      );
-    }
-
-    return Container(
-      // Reducimos un poco el ancho máximo ya que ahora es vertical
-      constraints: const BoxConstraints(maxWidth: 110),
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(12), // Un borde un poco menos redondo queda mejor con columnas
-        boxShadow: const [
-          BoxShadow(color: Colors.black12, blurRadius: 4),
-        ],
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          // Agrandé un poquitico el icono para que balancee con las dos líneas de texto
-          const Icon(Icons.wb_sunny, size: 16, color: Colors.orange),
-          const SizedBox(width: 8),
-          Flexible(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                // Línea 1: Temperatura
-                Text(
-                  '${weather.temperature.toStringAsFixed(0)}°C',
-                  style: const TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.w700, // Un poco más gordita para destacar
-                    height: 1.1, // Reduce el salto de línea para que se vean unidos
-                  ),
-                ),
-                // Línea 2: Descripción
-                Text(
-                  weather.description,
-                  style: const TextStyle(
-                    fontSize: 10,
-                    fontWeight: FontWeight.w400,
-                    color: Color(0xFF555555), // Un gris sutil
-                    height: 1.1,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ],
+        if (weather == null) {
+          return Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(16),
+              boxShadow: const [BoxShadow(color: Colors.black12, blurRadius: 4)],
             ),
+            child: const Text('--', style: TextStyle(fontSize: 11)),
+          );
+        }
+
+        return Container(
+          constraints: const BoxConstraints(maxWidth: 110),
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(12),
+            boxShadow: const [
+              BoxShadow(color: Colors.black12, blurRadius: 4),
+            ],
           ),
-        ],
-      ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.wb_sunny, size: 16, color: Colors.orange),
+              const SizedBox(width: 8),
+              Flexible(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '${weather.temperature.toStringAsFixed(0)}°C',
+                      style: const TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w700,
+                        height: 1.1,
+                      ),
+                    ),
+                    Text(
+                      weather.description,
+                      style: const TextStyle(
+                        fontSize: 10,
+                        fontWeight: FontWeight.w400,
+                        color: Color(0xFF555555),
+                        height: 1.1,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -7,6 +7,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
 import 'package:uniride/shared/widgets/bottom_nav_bar.dart';
 import 'package:uniride/shared/widgets/location_disabled_banner.dart';
+import 'package:uniride/shared/widgets/offline_banner.dart';
 
 import '../../core/db/daos/ride_dao.dart';
 import '../../core/db/database_helper.dart';
@@ -137,8 +138,17 @@ class _HomeScreenState extends State<HomeScreen> {
         ),
       ),
       bottomNavigationBar: const UniRideBottomNav(currentIndex: 0),
-      body: SafeArea(
-        child: SingleChildScrollView(
+      body: Column(
+        children: [
+          Consumer<RideViewModel>(
+            builder: (_, vm, _) => OfflineBanner(
+              isOffline: vm.isOffline,
+              isFromCache: vm.isFromCache,
+            ),
+          ),
+          Expanded(
+            child: SafeArea(
+              child: SingleChildScrollView(
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -226,6 +236,9 @@ class _HomeScreenState extends State<HomeScreen> {
             ],
           ),
         ),
+      ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/home/weather_viewmodel.dart
+++ b/lib/features/home/weather_viewmodel.dart
@@ -1,4 +1,8 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../data/repositories/weather_repository.dart';
 import '../../data/models/weather_model.dart';
@@ -10,17 +14,102 @@ class WeatherViewModel extends ChangeNotifier {
 
   WeatherData? _weather;
   bool _isLoading = false;
+  StreamController<WeatherData>? _weatherController;
+  Timer? _refreshTimer;
+  static const String _prefKey = 'last_weather_json';
 
   WeatherData? get weather => _weather;
   bool get isLoading => _isLoading;
+
+  Stream<WeatherData> get weatherStream {
+    _weatherController ??= StreamController<WeatherData>.broadcast();
+    return _weatherController!.stream;
+  }
 
   Future<void> loadWeather() async {
     _isLoading = true;
     notifyListeners();
 
-    _weather = await _repository.getCurrentWeather();
+    try {
+      _weather = await _repository.getCurrentWeather();
+      _weatherController?.add(_weather!);
+      await _saveWeatherToPrefs(_weather!);
+      debugPrint('[Weather] loaded from API: ${_weather!.temperature}°C');
+    } catch (e) {
+      debugPrint('[Weather] API failed: $e');
+      final saved = await _loadWeatherFromPrefs();
+      if (saved != null) {
+        _weather = saved;
+        _weatherController?.add(_weather!);
+        debugPrint('[Weather] loaded from SharedPreferences: ${saved.temperature}°C');
+      } else {
+        debugPrint('[Weather] no saved data, using defaultData');
+        _weather = WeatherData.defaultData;
+      }
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
 
-    _isLoading = false;
-    notifyListeners();
+  void startAutoRefresh({
+    Duration interval = const Duration(minutes: 15),
+  }) {
+    _refreshTimer?.cancel();
+    _refreshTimer = Timer.periodic(interval, (_) {
+      debugPrint('[Weather] auto-refresh triggered');
+      loadWeather();
+    });
+    final label = interval.inSeconds >= 60
+        ? '${interval.inMinutes}min'
+        : '${interval.inSeconds}s';
+    debugPrint('[Weather] auto-refresh started, interval=$label');
+  }
+
+  Future<void> _saveWeatherToPrefs(WeatherData w) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        _prefKey,
+        jsonEncode({
+          'temperature': w.temperature,
+          'description': w.description,
+          'willRainSoon': w.willRainSoon,
+          'precipitationProbability': w.precipitationProbability,
+          'weatherCode': w.weatherCode,
+        }),
+      );
+      debugPrint('[Weather] saving to prefs: ${w.temperature}°C');
+    } catch (e) {
+      debugPrint('[Weather] failed to save prefs: $e');
+    }
+  }
+
+  Future<WeatherData?> _loadWeatherFromPrefs() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(_prefKey);
+      if (raw == null) return null;
+      final map = jsonDecode(raw) as Map<String, dynamic>;
+      debugPrint('[Weather] loaded from SharedPreferences');
+      return WeatherData(
+        temperature: (map['temperature'] as num).toDouble(),
+        description: map['description'] as String,
+        willRainSoon: map['willRainSoon'] as bool,
+        precipitationProbability:
+            (map['precipitationProbability'] as num).toInt(),
+        weatherCode: (map['weatherCode'] as num?)?.toInt() ?? 0,
+      );
+    } catch (e) {
+      debugPrint('[Weather] failed to load prefs: $e');
+      return null;
+    }
+  }
+
+  @override
+  void dispose() {
+    _refreshTimer?.cancel();
+    _weatherController?.close();
+    super.dispose();
   }
 }

--- a/lib/features/rides/ride_viewmodel.dart
+++ b/lib/features/rides/ride_viewmodel.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 
+import '../../core/connectivity/connectivity_service.dart';
 import '../../data/repositories/impl/firebase_ride_repository.dart';
 import '../../data/repositories/ride_repository.dart';
 import '../../data/models/ride_model.dart';
@@ -7,7 +8,15 @@ import '../../data/models/ride_model.dart';
 class RideViewModel extends ChangeNotifier {
   final RideRepository _repository;
 
-  RideViewModel(this._repository);
+  RideViewModel(this._repository) {
+    ConnectivityService().onStatusChanged.listen((online) {
+      isOffline = !online;
+      notifyListeners();
+      if (online && isFromCache) {
+        invalidateAndReload();
+      }
+    });
+  }
 
   List<RideModel> _rides = [];
   bool _isLoading = false;
@@ -19,6 +28,7 @@ class RideViewModel extends ChangeNotifier {
   String _searchDestination = '';
 
   bool isFromCache = false;
+  bool isOffline = false;
 
   List<RideModel> get rides => _rides;
   bool get isLoading => _isLoading;

--- a/lib/features/rides/ride_viewmodel.dart
+++ b/lib/features/rides/ride_viewmodel.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 
 import '../../core/connectivity/connectivity_service.dart';
@@ -9,13 +11,32 @@ class RideViewModel extends ChangeNotifier {
   final RideRepository _repository;
 
   RideViewModel(this._repository) {
-    ConnectivityService().onStatusChanged.listen((online) {
-      isOffline = !online;
+    _setupConnectivityListener();
+  }
+
+  StreamSubscription<bool>? _connectivitySub;
+
+  void _setupConnectivityListener() {
+    _connectivitySub = ConnectivityService().onStatusChanged.listen((isOnline) {
+      final wasOffline = isOffline;
+      debugPrint('[Connectivity] online=$isOnline '
+          'wasOffline=$wasOffline isFromCache=$isFromCache');
+      isOffline = !isOnline;
       notifyListeners();
-      if (online && isFromCache) {
+      if (isOnline && (wasOffline || isFromCache)) {
+        debugPrint('[Connectivity] triggering reload '
+            '(wasOffline=$wasOffline isFromCache=$isFromCache)');
         invalidateAndReload();
+      } else if (isOnline) {
+        debugPrint('[Connectivity] online, no reload needed');
       }
     });
+  }
+
+  @override
+  void dispose() {
+    _connectivitySub?.cancel();
+    super.dispose();
   }
 
   List<RideModel> _rides = [];
@@ -47,7 +68,10 @@ class RideViewModel extends ChangeNotifier {
       final repo = _repository;
       if (repo is FirebaseRideRepository) {
         _rides = await repo.getAvailableRidesWithFallback(
-          onCacheStatus: (v) => isFromCache = v,
+          onCacheStatus: (v) {
+            isFromCache = v;
+            debugPrint('[RideVM] isFromCache set to $v');
+          },
         );
       } else {
         _rides = await _repository.getAvailableRides();
@@ -61,11 +85,13 @@ class RideViewModel extends ChangeNotifier {
   }
 
   Future<void> invalidateAndReload() async {
+    debugPrint('[RideVM] invalidateAndReload started');
     final repo = _repository;
     if (repo is FirebaseRideRepository) {
       repo.invalidateRideCache();
     }
     await loadAvailableRides();
+    debugPrint('[RideVM] invalidateAndReload done, isFromCache=$isFromCache');
   }
 
   void setSearchTerms(String origin, String destination) {

--- a/lib/features/rides/ride_viewmodel.dart
+++ b/lib/features/rides/ride_viewmodel.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 
+import '../../data/repositories/impl/firebase_ride_repository.dart';
 import '../../data/repositories/ride_repository.dart';
 import '../../data/models/ride_model.dart';
 
@@ -17,6 +18,8 @@ class RideViewModel extends ChangeNotifier {
   String _searchOrigin = '';
   String _searchDestination = '';
 
+  bool isFromCache = false;
+
   List<RideModel> get rides => _rides;
   bool get isLoading => _isLoading;
   String? get errorMessage => _errorMessage;
@@ -31,13 +34,28 @@ class RideViewModel extends ChangeNotifier {
     notifyListeners();
 
     try {
-      _rides = await _repository.getAvailableRides();
+      final repo = _repository;
+      if (repo is FirebaseRideRepository) {
+        _rides = await repo.getAvailableRidesWithFallback(
+          onCacheStatus: (v) => isFromCache = v,
+        );
+      } else {
+        _rides = await _repository.getAvailableRides();
+      }
     } catch (e) {
       _errorMessage = e.toString().replaceFirst('Exception: ', '');
     }
 
     _isLoading = false;
     notifyListeners();
+  }
+
+  Future<void> invalidateAndReload() async {
+    final repo = _repository;
+    if (repo is FirebaseRideRepository) {
+      repo.invalidateRideCache();
+    }
+    await loadAvailableRides();
   }
 
   void setSearchTerms(String origin, String destination) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'core/routes.dart';
 import 'data/repositories/impl/firebase_auth_repository.dart';
 import 'data/repositories/impl/firebase_ride_repository.dart';
 import 'data/repositories/impl/open_meteo_repository.dart';
+import 'data/models/weather_model.dart';
 import 'data/repositories/user_repository.dart';
 import 'features/auth/auth_viewmodel.dart';
 import 'features/home/weather_viewmodel.dart';
@@ -25,6 +26,13 @@ Future<void> main() async {
 
   FirebaseFirestore.instance.settings =
       const Settings(persistenceEnabled: false);
+
+  // Future + callback — fire-and-forget weather prefetch at boot
+  OpenMeteoRepository().fetchCurrentWithCallback(
+    onSuccess: (WeatherData data) =>
+        debugPrint('[Boot] weather prefetch: ${data.temperature}°C'),
+    onError: (e) => debugPrint('[Boot] weather prefetch failed: $e'),
+  );
 
   runApp(const UniRideBootstrap());
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -21,6 +22,9 @@ Future<void> main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
+
+  FirebaseFirestore.instance.settings =
+      const Settings(persistenceEnabled: false);
 
   runApp(const UniRideBootstrap());
 }

--- a/lib/shared/widgets/offline_banner.dart
+++ b/lib/shared/widgets/offline_banner.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+class OfflineBanner extends StatelessWidget {
+  const OfflineBanner({
+    super.key,
+    required this.isOffline,
+    required this.isFromCache,
+  });
+
+  final bool isOffline;
+  final bool isFromCache;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!isOffline && !isFromCache) return const SizedBox.shrink();
+
+    final message = isOffline
+        ? 'No connection — showing saved data'
+        : 'Cached data — refreshing...';
+
+    final bgColor = isOffline
+        ? const Color(0xFFD32F2F)
+        : const Color(0xFFF57C00);
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 300),
+      height: isOffline || isFromCache ? 36 : 0,
+      color: bgColor,
+      child: Center(
+        child: Text(
+          message,
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 12,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
PR Description:                                                                                                                                                                                                                      
                                                                                                                                                                                                                                       
  ## What was implemented                                                                                                                                                                                                              
                                                            
  ### Strategy 1 — Local Storage
  - SQLite `rides` table via `sqflite` with `insertOrReplaceAll` (batch), `fetchAll`, `deleteExpiredRides` (departure_time < now), and `deleteStaleRides` (cached_at > 6h)
  - `RideEntityExtension` maps `RideModel` ↔ DB rows; `hasRainForecast` intentionally excluded (runtime-only field)                                                                                                                    
  - SharedPreferences stores last weather JSON under key `last_weather_json`; loaded as fallback when API fails offline                                                                                                                
  - Firestore `persistenceEnabled: false` — SQLite is the sole offline cache, making the strategy demonstrable in Viva Voce                                                                                                            
                                                                                                                                                                                                                                       
  ### Strategy 2 — Caching (LRU)                                                                                                                                                                                                       
  - `LRUCache<K,V>` backed by `LinkedHashMap`, capacity 50 (~100KB max, covers 5-10 filter combos per session)                                                                                                                         
  - `get()` moves accessed key to most-recent position; `put()` evicts least-recently-used when full                                                                                                                                   
  - Integrated in `FirebaseRideRepository.getAvailableRidesWithFallback()`: LRU hit → return immediately; Firestore success → LRU.put + async SQLite write; Firestore fail → SQLite → LRU.put                                          
  - `onCacheStatus(false)` on LRU hit and Firestore success; `onCacheStatus(true)` only on SQLite fallback                                                                                                                             
                                                                                                                                                                                                                                       
  ### Strategy 3 — Eventual Connectivity                                                                                                                                                                                               
  - `ConnectivityService` singleton exposes `Stream<bool> onStatusChanged` and `Future<bool> isOnline()`                                                                                                                               
  - `RideViewModel` subscribes in its constructor, stores `StreamSubscription`, cancels in `dispose()`                                                                                                                                 
  - On reconnect: reloads if `wasOffline || isFromCache`; `isFromCache` resets to `false` after Firestore success → banner disappears automatically                                                                                    
  - `OfflineBanner` widget: red (no connection), amber (cached data), hidden (live data); placed as first child inside `SafeArea` with no extra wrapper                                                                                
                                                                                                                                                                                                                                       
  ### Strategy 4 — Concurrency                                                                                                                                                                                                         
  - **Future + callback**: `OpenMeteoRepository.fetchCurrentWithCallback()` using `.then().catchError()`; called fire-and-forget at boot in `main.dart`                                                                                
  - **Future + async/await**: all repo and ViewModel methods use `async/await` with `try/catch/finally`                                                                                                                                
  - **Stream**: `WeatherViewModel` exposes `Stream<WeatherData>` via `StreamController.broadcast()`; `Timer.periodic` every 15 min auto-refreshes weather; `_WeatherChip` uses `StreamBuilder` with `initialData` for zero-flash       
  rendering; `dispose()` cancels timer and closes stream                                                                                                                                                                               
  - **GPS auto-refresh**: `_SearchCardState` subscribes to `ConnectivityService` to re-trigger location on reconnect, plus `Timer.periodic` every 5 min                                                                                
                                                                                                                                                                                                                                       
  ## Why Firestore persistence is disabled                                                                                                                                                                                             
  Firestore's built-in cache would mask the SQLite fallback during demos — with it enabled, Firestore serves stale data silently and the SQLite strategy is invisible. Disabling it makes the offline → SQLite → amber banner flow     
  fully observable.                                                                                                                                                                                                                    
  
  
  close #27 