### PR TITLE
Feature/driver screens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ macos/Flutter/GeneratedPluginRegistrant.swift
 macos/Flutter/ephemeral/
 windows/flutter/ephemeral/
 CODEBASE.md
+
+
+.env

--- a/lib/core/connectivity/sync_manager.dart
+++ b/lib/core/connectivity/sync_manager.dart
@@ -1,0 +1,33 @@
+import 'package:sqflite/sqflite.dart';
+import 'package:uuid/uuid.dart';
+
+import '../db/database_helper.dart';
+
+class SyncManager {
+  SyncManager._internal();
+  static final SyncManager _instance = SyncManager._internal();
+  factory SyncManager() => _instance;
+
+  final DatabaseHelper _db = DatabaseHelper();
+  static const _table = 'pending_operations';
+
+  Future<void> enqueue(String operation, String payload) async {
+    final db = await _db.database;
+    await db.insert(_table, {
+      'id': const Uuid().v4(),
+      'operation': operation,
+      'payload': payload,
+      'created_at': DateTime.now().millisecondsSinceEpoch,
+    }, conflictAlgorithm: ConflictAlgorithm.replace);
+  }
+
+  Future<List<Map<String, dynamic>>> pendingAll() async {
+    final db = await _db.database;
+    return db.query(_table, orderBy: 'created_at ASC');
+  }
+
+  Future<void> remove(String id) async {
+    final db = await _db.database;
+    await db.delete(_table, where: 'id = ?', whereArgs: [id]);
+  }
+}

--- a/lib/core/db/daos/ride_dao.dart
+++ b/lib/core/db/daos/ride_dao.dart
@@ -42,11 +42,14 @@ class RideDao {
 
   Future<void> deleteExpiredRides() async {
     final db = await _helper.database;
-    final nowMs = DateTime.now().millisecondsSinceEpoch;
+    // 15-minute grace so drivers can still start a ride after its scheduled time
+    final cutoffMs = DateTime.now()
+        .subtract(const Duration(minutes: 15))
+        .millisecondsSinceEpoch;
     final deleted = await db.delete(
       'rides',
       where: 'departure_time < ?',
-      whereArgs: [nowMs],
+      whereArgs: [cutoffMs],
     );
     debugPrint('[SQLite] deleted $deleted expired rides');
   }

--- a/lib/core/db/database_helper.dart
+++ b/lib/core/db/database_helper.dart
@@ -19,7 +19,7 @@ class DatabaseHelper {
     final path = join(dir.path, 'uniride.db');
     return openDatabase(
       path,
-      version: 1,
+      version: 2,
       onCreate: _onCreate,
       onUpgrade: _onUpgrade,
     );
@@ -46,9 +46,21 @@ class DatabaseHelper {
     ''');
     await db.execute('CREATE INDEX idx_rides_zone ON rides(zone)');
     await db.execute('CREATE INDEX idx_rides_status ON rides(status)');
+    await _createPendingOperationsTable(db);
   }
 
   Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
-    // Future migrations go here.
+    if (oldVersion < 2) await _createPendingOperationsTable(db);
+  }
+
+  Future<void> _createPendingOperationsTable(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS pending_operations (
+        id TEXT PRIMARY KEY,
+        operation TEXT NOT NULL,
+        payload TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      )
+    ''');
   }
 }

--- a/lib/core/routes.dart
+++ b/lib/core/routes.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:uniride/data/repositories/impl/firebase_ride_repository.dart';
@@ -79,6 +80,26 @@ final appRouter = GoRouter(
     GoRoute(
       path: '/nfc',
       builder: (context, state) => const NfcAccessScreen(),
+    ),
+    GoRoute(
+      path: '/driver/create-ride',
+      builder: (_, __) => const Scaffold(
+          body: Center(child: Text('Create Ride'))),
+    ),
+    GoRoute(
+      path: '/driver/my-rides',
+      builder: (_, __) => const Scaffold(
+          body: Center(child: Text('My Rides'))),
+    ),
+    GoRoute(
+      path: '/driver/ride-requests',
+      builder: (_, __) => const Scaffold(
+          body: Center(child: Text('Ride Requests'))),
+    ),
+    GoRoute(
+      path: '/driver/active-ride',
+      builder: (_, __) => const Scaffold(
+          body: Center(child: Text('Active Ride'))),
     ),
   ],
 );

--- a/lib/core/routes.dart
+++ b/lib/core/routes.dart
@@ -21,6 +21,7 @@ import 'package:uniride/features/driver/my_rides/driver_ride_detail_screen.dart'
 import 'package:uniride/features/driver/my_rides/driver_ride_detail_viewmodel.dart';
 import 'package:uniride/features/driver/my_rides/my_rides_screen.dart';
 import 'package:uniride/features/driver/my_rides/my_rides_viewmodel.dart';
+import 'package:uniride/features/driver/active_ride/active_ride_screen.dart';
 import 'package:uniride/features/driver/ride_requests/ride_requests_screen.dart';
 import 'package:uniride/features/driver/ride_requests/ride_requests_viewmodel.dart';
 import 'package:uniride/features/rides/ride_details_screen.dart';
@@ -133,8 +134,11 @@ final appRouter = GoRouter(
     ),
     GoRoute(
       path: '/driver/active-ride',
-      builder: (context, state) => const Scaffold(
-          body: Center(child: Text('Active Ride'))),
+      builder: (context, state) {
+        final extra = state.extra as Map<String, dynamic>?;
+        final rideId = (extra?['rideId'] as String?) ?? '';
+        return ActiveRideScreen(rideId: rideId);
+      },
     ),
   ],
 );

--- a/lib/core/routes.dart
+++ b/lib/core/routes.dart
@@ -14,6 +14,8 @@ import 'package:uniride/features/home/home_screen.dart';
 import 'package:uniride/features/nfc/nfc_access_screen.dart';
 import 'package:uniride/features/profile/profile_screen.dart';
 import 'package:uniride/features/rides/available_rides_screen.dart';
+import 'package:uniride/features/driver/create_ride/create_ride_screen.dart';
+import 'package:uniride/features/driver/create_ride/create_ride_viewmodel.dart';
 import 'package:uniride/features/rides/ride_details_screen.dart';
 import 'package:uniride/features/rides/ride_details_viewmodel.dart';
 
@@ -83,8 +85,10 @@ final appRouter = GoRouter(
     ),
     GoRoute(
       path: '/driver/create-ride',
-      builder: (_, __) => const Scaffold(
-          body: Center(child: Text('Create Ride'))),
+      builder: (context, state) => ChangeNotifierProvider(
+        create: (_) => CreateRideViewModel(),
+        child: const CreateRideScreen(),
+      ),
     ),
     GoRoute(
       path: '/driver/my-rides',

--- a/lib/core/routes.dart
+++ b/lib/core/routes.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+import 'package:uniride/data/models/ride_model.dart';
 import 'package:uniride/data/repositories/impl/firebase_ride_repository.dart';
 import 'package:uniride/features/auth/login_screen.dart';
 import 'package:uniride/features/auth/register_screen.dart';
@@ -16,6 +17,10 @@ import 'package:uniride/features/profile/profile_screen.dart';
 import 'package:uniride/features/rides/available_rides_screen.dart';
 import 'package:uniride/features/driver/create_ride/create_ride_screen.dart';
 import 'package:uniride/features/driver/create_ride/create_ride_viewmodel.dart';
+import 'package:uniride/features/driver/my_rides/driver_ride_detail_screen.dart';
+import 'package:uniride/features/driver/my_rides/driver_ride_detail_viewmodel.dart';
+import 'package:uniride/features/driver/my_rides/my_rides_screen.dart';
+import 'package:uniride/features/driver/my_rides/my_rides_viewmodel.dart';
 import 'package:uniride/features/rides/ride_details_screen.dart';
 import 'package:uniride/features/rides/ride_details_viewmodel.dart';
 
@@ -92,17 +97,32 @@ final appRouter = GoRouter(
     ),
     GoRoute(
       path: '/driver/my-rides',
-      builder: (_, __) => const Scaffold(
-          body: Center(child: Text('My Rides'))),
+      builder: (context, state) => ChangeNotifierProvider(
+        create: (_) => MyRidesViewModel(),
+        child: const MyRidesScreen(),
+      ),
+    ),
+    GoRoute(
+      path: '/driver/my-rides/:rideId',
+      builder: (context, state) {
+        final ride = state.extra! as RideModel;
+        return ChangeNotifierProvider(
+          create: (_) => DriverRideDetailViewModel(
+            ride,
+            FirebaseRideRepository(),
+          ),
+          child: const DriverRideDetailScreen(),
+        );
+      },
     ),
     GoRoute(
       path: '/driver/ride-requests',
-      builder: (_, __) => const Scaffold(
+      builder: (context, state) => const Scaffold(
           body: Center(child: Text('Ride Requests'))),
     ),
     GoRoute(
       path: '/driver/active-ride',
-      builder: (_, __) => const Scaffold(
+      builder: (context, state) => const Scaffold(
           body: Center(child: Text('Active Ride'))),
     ),
   ],

--- a/lib/core/routes.dart
+++ b/lib/core/routes.dart
@@ -21,6 +21,8 @@ import 'package:uniride/features/driver/my_rides/driver_ride_detail_screen.dart'
 import 'package:uniride/features/driver/my_rides/driver_ride_detail_viewmodel.dart';
 import 'package:uniride/features/driver/my_rides/my_rides_screen.dart';
 import 'package:uniride/features/driver/my_rides/my_rides_viewmodel.dart';
+import 'package:uniride/features/driver/ride_requests/ride_requests_screen.dart';
+import 'package:uniride/features/driver/ride_requests/ride_requests_viewmodel.dart';
 import 'package:uniride/features/rides/ride_details_screen.dart';
 import 'package:uniride/features/rides/ride_details_viewmodel.dart';
 
@@ -117,8 +119,17 @@ final appRouter = GoRouter(
     ),
     GoRoute(
       path: '/driver/ride-requests',
-      builder: (context, state) => const Scaffold(
-          body: Center(child: Text('Ride Requests'))),
+      builder: (context, state) {
+        final extra = state.extra as Map<String, dynamic>?;
+        return ChangeNotifierProvider(
+          create: (_) => RideRequestsViewModel(
+            rideId: (extra?['rideId'] as String?) ?? '',
+            origin: (extra?['origin'] as String?) ?? '',
+            destination: (extra?['destination'] as String?) ?? '',
+          ),
+          child: const RideRequestsScreen(),
+        );
+      },
     ),
     GoRoute(
       path: '/driver/active-ride',

--- a/lib/core/utils/geocoding_service.dart
+++ b/lib/core/utils/geocoding_service.dart
@@ -3,6 +3,20 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
+class PlaceSuggestion {
+  final String displayName;
+  final String fullName;
+  final double lat;
+  final double lon;
+
+  const PlaceSuggestion({
+    required this.displayName,
+    required this.fullName,
+    required this.lat,
+    required this.lon,
+  });
+}
+
 class GeocodingService {
   static const String _baseUrl =
       'https://nominatim.openstreetmap.org/reverse';
@@ -55,5 +69,65 @@ class GeocodingService {
       debugPrint('[Geocoding] failed: $e');
       return null;
     }
+  }
+
+  /// Forward geocoding via Nominatim — returns up to 5 place suggestions.
+  static Future<List<PlaceSuggestion>> searchPlaces(String query) async {
+    if (query.trim().length < 3) return [];
+    try {
+      final uri =
+          Uri.parse('https://nominatim.openstreetmap.org/search').replace(
+        queryParameters: {
+          'q': '${query.trim()}, Bogotá, Colombia',
+          'format': 'json',
+          'limit': '5',
+          'addressdetails': '1',
+          'accept-language': 'es',
+        },
+      );
+      final response = await http
+          .get(uri,
+              headers: {'User-Agent': 'UniRide/1.0 (university project)'})
+          .timeout(const Duration(seconds: 5));
+
+      if (response.statusCode != 200) return [];
+
+      final results = jsonDecode(response.body) as List<dynamic>;
+      return results.map((r) {
+        final map = r as Map<String, dynamic>;
+        return PlaceSuggestion(
+          displayName: _shortName(map),
+          fullName: map['display_name'] as String,
+          lat: double.parse(map['lat'] as String),
+          lon: double.parse(map['lon'] as String),
+        );
+      }).toList();
+    } catch (e) {
+      debugPrint('[Geocoding] search failed: $e');
+      return [];
+    }
+  }
+
+  static String _shortName(Map<String, dynamic> map) {
+    final addr = map['address'] as Map<String, dynamic>?;
+    if (addr == null) {
+      return (map['display_name'] as String)
+          .split(',')
+          .take(2)
+          .join(',')
+          .trim();
+    }
+    final name = addr['amenity'] as String? ??
+        addr['building'] as String? ??
+        addr['road'] as String? ??
+        addr['neighbourhood'] as String? ??
+        addr['suburb'] as String?;
+    final city = addr['city_district'] as String? ?? addr['suburb'] as String?;
+    if (name != null && city != null) return '$name, $city';
+    return (map['display_name'] as String)
+        .split(',')
+        .take(2)
+        .join(',')
+        .trim();
   }
 }

--- a/lib/core/utils/geocoding_service.dart
+++ b/lib/core/utils/geocoding_service.dart
@@ -90,6 +90,11 @@ class GeocodingService {
               headers: {'User-Agent': 'UniRide/1.0 (university project)'})
           .timeout(const Duration(seconds: 5));
 
+      debugPrint('[Geocoding] status=${response.statusCode} query="$query"');
+      if (response.statusCode == 429) {
+        debugPrint('[Geocoding] rate-limited by Nominatim — wait a minute');
+        return [];
+      }
       if (response.statusCode != 200) return [];
 
       final results = jsonDecode(response.body) as List<dynamic>;

--- a/lib/data/models/notification_model.dart
+++ b/lib/data/models/notification_model.dart
@@ -1,0 +1,47 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class NotificationModel {
+  final String id;
+  final String userId;
+  final String type; // 'accepted' | 'rejected' | 'new_request'
+  final String rideId;
+  final String origin;
+  final String destination;
+  final String message;
+  final bool read;
+  final DateTime createdAt;
+
+  const NotificationModel({
+    required this.id,
+    required this.userId,
+    required this.type,
+    required this.rideId,
+    required this.origin,
+    required this.destination,
+    required this.message,
+    required this.read,
+    required this.createdAt,
+  });
+
+  factory NotificationModel.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    final raw = data['createdAt'];
+    final DateTime time = raw is Timestamp
+        ? raw.toDate()
+        : raw is DateTime
+            ? raw
+            : DateTime.now();
+
+    return NotificationModel(
+      id: doc.id,
+      userId: (data['userId'] as String?) ?? '',
+      type: (data['type'] as String?) ?? 'accepted',
+      rideId: (data['rideId'] as String?) ?? '',
+      origin: (data['origin'] as String?) ?? '',
+      destination: (data['destination'] as String?) ?? '',
+      message: (data['message'] as String?) ?? '',
+      read: (data['read'] as bool?) ?? false,
+      createdAt: time,
+    );
+  }
+}

--- a/lib/data/models/ride_request_model.dart
+++ b/lib/data/models/ride_request_model.dart
@@ -1,0 +1,43 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class RideRequestModel {
+  final String id;
+  final String rideId;
+  final String passengerId;
+  final String passengerName;
+  final double passengerRating;
+  final String status;
+  final DateTime requestTime;
+
+  const RideRequestModel({
+    required this.id,
+    required this.rideId,
+    required this.passengerId,
+    required this.passengerName,
+    required this.passengerRating,
+    required this.status,
+    required this.requestTime,
+  });
+
+  factory RideRequestModel.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    final raw = data['requestTime'];
+    final DateTime time = raw is Timestamp
+        ? raw.toDate()
+        : raw is DateTime
+            ? raw
+            : DateTime.now();
+
+    return RideRequestModel(
+      id: doc.id,
+      rideId: (data['rideId'] as String?) ?? '',
+      passengerId: (data['passengerId'] as String?) ?? '',
+      passengerName: (data['passengerName'] as String?) ?? 'Unknown',
+      passengerRating: (data['passengerRating'] as num?)?.toDouble() ??
+          (data['reputationScore'] as num?)?.toDouble() ??
+          0.0,
+      status: (data['status'] as String?) ?? 'pending',
+      requestTime: time,
+    );
+  }
+}

--- a/lib/data/repositories/impl/firebase_ride_repository.dart
+++ b/lib/data/repositories/impl/firebase_ride_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
 import 'package:flutter/foundation.dart';
 
 import '../../../core/cache/lru_cache.dart';
@@ -28,7 +29,7 @@ class FirebaseRideRepository implements RideRepository {
     try {
       final snapshot = await _firestore
           .collection('rides')
-          .where('status', isEqualTo: 'available')
+          .where('status', whereIn: ['available', 'active'])
           .get();
 
       return snapshot.docs.map((doc) {
@@ -49,7 +50,7 @@ class FirebaseRideRepository implements RideRepository {
   Future<List<RideModel>> getMatchingRides(String userId) async {
     final snapshot = await _firestore
         .collection('rides')
-        .where('status', isEqualTo: 'available')
+        .where('status', whereIn: ['available', 'active'])
         .get();
 
     return snapshot.docs
@@ -96,6 +97,50 @@ class FirebaseRideRepository implements RideRepository {
 
   void invalidateRideCache() => _lruCache.invalidateAll();
 
+  Future<void> updateRide({
+    required String rideId,
+    String? origin,
+    String? destination,
+    DateTime? departureTime,
+    int? seatsAvailable,
+    double? price,
+  }) async {
+    final payload = <String, dynamic>{'rideId': rideId};
+    if (origin != null) payload['origin'] = origin;
+    if (destination != null) payload['destination'] = destination;
+    if (departureTime != null) {
+      payload['departureTime'] = departureTime.millisecondsSinceEpoch;
+    }
+    if (seatsAvailable != null) payload['seatsAvailable'] = seatsAvailable;
+    if (price != null) payload['price'] = price;
+
+    final cf = FirebaseFunctions.instanceFor(region: 'us-central1')
+        .httpsCallable('updateRide');
+    await cf.call(payload);
+    invalidateRideCache();
+  }
+
+  Future<void> deleteRide(String rideId) async {
+    final cf = FirebaseFunctions.instanceFor(region: 'us-central1')
+        .httpsCallable('deleteRide');
+    await cf.call({'rideId': rideId});
+    invalidateRideCache();
+  }
+
+  Future<List<RideModel>> getDriverRides(String driverId) async {
+    final snap = await _firestore
+        .collection('rides')
+        .where('driverId', isEqualTo: driverId)
+        .get();
+    final now = DateTime.now();
+    final rides = snap.docs
+        .map((d) => RideModel.fromMap(d.data(), d.id))
+        .where((r) => r.departureTime.isAfter(now) || r.status == 'in_progress')
+        .toList()
+      ..sort((a, b) => a.departureTime.compareTo(b.departureTime));
+    return rides;
+  }
+
   @override
   Future<RideDetailsModel> getRideDetails(String rideId) async {
     final rideDoc = await _firestore.collection('rides').doc(rideId).get();
@@ -107,15 +152,6 @@ class FirebaseRideRepository implements RideRepository {
     final rideData = rideDoc.data()!;
     final rawDriverId = (rideData['driverId'] as String?) ?? '';
     final driverId = _normalizeDriverId(rawDriverId);
-
-    Map<String, dynamic> driverData = {};
-    if (driverId.isNotEmpty) {
-      final driverDoc =
-          await _firestore.collection('users').doc(driverId).get();
-      if (driverDoc.exists && driverDoc.data() != null) {
-        driverData = driverDoc.data()!;
-      }
-    }
 
     final departureTime =
         _readDateTime(rideData['departureTime']) ?? DateTime.now();

--- a/lib/features/auth/auth_viewmodel.dart
+++ b/lib/features/auth/auth_viewmodel.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_functions/cloud_functions.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 
 import '../../core/connectivity/connectivity_service.dart';
@@ -13,15 +14,29 @@ class AuthViewModel extends ChangeNotifier {
 
   AuthViewModel(this._repository) {
     _setupConnectivityListener();
+    _setupAuthStateListener();
   }
 
   StreamSubscription<bool>? _connectivitySub;
+  StreamSubscription<User?>? _authStateSub;
   bool isOffline = false;
 
   void _setupConnectivityListener() {
     _connectivitySub = ConnectivityService().onStatusChanged.listen((isOnline) {
       isOffline = !isOnline;
       notifyListeners();
+    });
+  }
+
+  void _setupAuthStateListener() {
+    _authStateSub = FirebaseAuth.instance.authStateChanges().listen((user) async {
+      if (user != null && _currentUser == null) {
+        _currentUser = await _repository.getUserProfile(user.uid);
+        notifyListeners();
+      } else if (user == null) {
+        _currentUser = null;
+        notifyListeners();
+      }
     });
   }
 
@@ -33,6 +48,7 @@ class AuthViewModel extends ChangeNotifier {
   @override
   void dispose() {
     _connectivitySub?.cancel();
+    _authStateSub?.cancel();
     super.dispose();
   }
 
@@ -40,11 +56,26 @@ class AuthViewModel extends ChangeNotifier {
   String? _errorMessage;
   UserModel? _currentUser;
   List<Map<String, dynamic>> _recurringRoutes = [];
+  String _activeMode = 'passenger';
 
   bool get isLoading => _isLoading;
   String? get errorMessage => _errorMessage;
   UserModel? get currentUser => _currentUser;
   List<Map<String, dynamic>> get recurringRoutes => _recurringRoutes;
+  String get activeMode => _activeMode;
+
+  void setActiveMode(String mode) {
+    _activeMode = mode;
+    notifyListeners();
+  }
+
+  Future<void> refreshCurrentUser() async {
+    final uid = await _repository.getCurrentUserId();
+    if (uid != null) {
+      _currentUser = await _repository.getUserProfile(uid);
+      notifyListeners();
+    }
+  }
 
   Future<bool> signIn(String email, String password) async {
     _isLoading = true;

--- a/lib/features/auth/register_screen.dart
+++ b/lib/features/auth/register_screen.dart
@@ -243,7 +243,7 @@ class _RegisterBodyState extends State<_RegisterBody> {
                               onTap: () => vm.setRole('passenger'),
                             ),
                           ),
-                          const SizedBox(width: 12),
+                          const SizedBox(width: 8),
                           Expanded(
                             child: _RoleButton(
                               label: 'Driver',
@@ -252,8 +252,27 @@ class _RegisterBodyState extends State<_RegisterBody> {
                               onTap: () => vm.setRole('driver'),
                             ),
                           ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: _RoleButton(
+                              label: 'Both',
+                              icon: Icons.people,
+                              selected: vm.role == 'both',
+                              onTap: () => vm.setRole('both'),
+                            ),
+                          ),
                         ],
                       ),
+                      if (vm.role == 'both') ...[
+                        const SizedBox(height: 6),
+                        Text(
+                          'You can switch between modes in your profile',
+                          style: GoogleFonts.poppins(
+                            fontSize: 11,
+                            color: _Colors.muted,
+                          ),
+                        ),
+                      ],
                       const SizedBox(height: 16),
 
                       // Gender selector

--- a/lib/features/auth/register_viewmodel.dart
+++ b/lib/features/auth/register_viewmodel.dart
@@ -55,7 +55,7 @@ class RegisterViewModel extends ChangeNotifier {
 
   void setRole(String value) {
     role = value;
-    showVehicleField = (value == 'driver');
+    showVehicleField = (value == 'driver' || value == 'both');
     notifyListeners();
   }
 
@@ -72,7 +72,7 @@ class RegisterViewModel extends ChangeNotifier {
     if (password.length < 6) return 'Password must be at least 6 characters';
     if (password != confirmPassword) return 'Passwords do not match';
     if (gender.isEmpty) return 'Please select your gender';
-    if (role == 'driver') {
+    if (role == 'driver' || role == 'both') {
       final plate = vehiclePlate.trim().toUpperCase();
       if (plate.isEmpty) return 'Vehicle plate is required for drivers';
       final plateRegex = RegExp(r'^[A-Z]{3}\d{3}$');

--- a/lib/features/driver/active_ride/active_ride_screen.dart
+++ b/lib/features/driver/active_ride/active_ride_screen.dart
@@ -1,0 +1,201 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/connectivity/connectivity_service.dart';
+import '../../../shared/widgets/offline_banner.dart';
+
+class ActiveRideScreen extends StatefulWidget {
+  const ActiveRideScreen({super.key, required this.rideId});
+
+  final String rideId;
+
+  @override
+  State<ActiveRideScreen> createState() => _ActiveRideScreenState();
+}
+
+class _ActiveRideScreenState extends State<ActiveRideScreen> {
+  bool _isOffline = false;
+  bool _isLoading = false;
+  StreamSubscription<bool>? _connSub;
+  StreamSubscription<DocumentSnapshot>? _rideSub;
+
+  @override
+  void initState() {
+    super.initState();
+    ConnectivityService().isOnline().then((online) {
+      if (mounted) setState(() => _isOffline = !online);
+    });
+    _connSub = ConnectivityService().onStatusChanged.listen((online) {
+      if (mounted) setState(() => _isOffline = !online);
+    });
+
+    // Watch the ride document — if it becomes completed/cancelled externally,
+    // navigate home automatically.
+    _rideSub = FirebaseFirestore.instance
+        .collection('rides')
+        .doc(widget.rideId)
+        .snapshots()
+        .listen((snap) {
+      if (!mounted) return;
+      final status = (snap.data()?['status'] as String?) ?? '';
+      if (status == 'completed' || status == 'cancelled') {
+        context.go('/home');
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _connSub?.cancel();
+    _rideSub?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _finishRide() async {
+    setState(() => _isLoading = true);
+    try {
+      await FirebaseFunctions.instance
+          .httpsCallable('finishRide')
+          .call({'rideId': widget.rideId});
+      // Navigation is handled by _rideSub reacting to status → completed
+    } catch (e) {
+      debugPrint('[ActiveRide] finishRide error: $e');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('No se pudo finalizar el viaje. Intenta de nuevo.'),
+          ),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        title: const Text(
+          'Active Ride',
+          style: TextStyle(
+            fontSize: 18,
+            fontWeight: FontWeight.w600,
+            color: Color(0xFF111111),
+          ),
+        ),
+        iconTheme: const IconThemeData(color: Color(0xFF111111)),
+      ),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          OfflineBanner(isOffline: _isOffline, isFromCache: false),
+
+          // Map placeholder
+          Container(
+            height: 200,
+            margin: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: Colors.grey[200],
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: Colors.grey[300]!),
+            ),
+            child: Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.map_outlined, size: 48, color: Colors.grey[400]),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Map coming soon',
+                    style: TextStyle(color: Colors.grey[500], fontSize: 13),
+                  ),
+                ],
+              ),
+            ),
+          ),
+
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 16),
+            child: Text(
+              'Passengers',
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+            ),
+          ),
+
+          Expanded(
+            child: StreamBuilder<QuerySnapshot>(
+              stream: FirebaseFirestore.instance
+                  .collection('rideRequests')
+                  .where('rideId', isEqualTo: widget.rideId)
+                  .where('status', isEqualTo: 'accepted')
+                  .snapshots(),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                final docs = snapshot.data?.docs ?? [];
+                if (docs.isEmpty) {
+                  return const Padding(
+                    padding: EdgeInsets.all(16),
+                    child: Text('No passengers yet'),
+                  );
+                }
+                return ListView.builder(
+                  itemCount: docs.length,
+                  itemBuilder: (context, i) {
+                    final data = docs[i].data() as Map<String, dynamic>;
+                    final name =
+                        (data['passengerName'] as String?) ?? 'Passenger';
+                    final rating =
+                        (data['rating'] as num?)?.toStringAsFixed(1) ?? '–';
+                    return ListTile(
+                      leading: CircleAvatar(
+                        child: Text(name.isNotEmpty ? name[0] : '?'),
+                      ),
+                      title: Text(name),
+                      subtitle: Text('Rating: $rating'),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: SizedBox(
+              width: double.infinity,
+              height: 52,
+              child: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.red[600],
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                onPressed: (_isOffline || _isLoading) ? null : _finishRide,
+                child: _isLoading
+                    ? const CircularProgressIndicator(color: Colors.white)
+                    : const Text(
+                        'Finish Ride',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/driver/active_ride/active_ride_screen.dart
+++ b/lib/features/driver/active_ride/active_ride_screen.dart
@@ -3,9 +3,11 @@ import 'dart:async';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../core/connectivity/connectivity_service.dart';
+import '../../../core/location_utils.dart';
 import '../../../shared/widgets/offline_banner.dart';
 
 class ActiveRideScreen extends StatefulWidget {
@@ -58,17 +60,39 @@ class _ActiveRideScreenState extends State<ActiveRideScreen> {
   Future<void> _finishRide() async {
     setState(() => _isLoading = true);
     try {
-      await FirebaseFunctions.instance
-          .httpsCallable('finishRide')
-          .call({'rideId': widget.rideId});
-      // Navigation is handled by _rideSub reacting to status → completed
+      // Get current GPS location to validate proximity to destination
+      final Position? position = await LocationUtils.getCurrentPosition();
+
+      await FirebaseFunctions.instance.httpsCallable('finishRide').call({
+        'rideId': widget.rideId,
+        if (position != null) 'driverLat': position.latitude,
+        if (position != null) 'driverLng': position.longitude,
+      });
+      // Navigation handled by _rideSub reacting to status → completed
+    } on FirebaseFunctionsException catch (e) {
+      debugPrint('[ActiveRide] finishRide error: ${e.message}');
+      if (mounted) {
+        final message = e.message ?? 'No se pudo finalizar el viaje.';
+        // Surface distance error clearly; generic fallback for other errors
+        final isLocationError = message.contains('500m') ||
+            message.contains('destination');
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              isLocationError
+                  ? message
+                  : 'No se pudo finalizar el viaje. Intenta de nuevo.',
+            ),
+            duration: Duration(seconds: isLocationError ? 5 : 3),
+          ),
+        );
+      }
     } catch (e) {
-      debugPrint('[ActiveRide] finishRide error: $e');
+      debugPrint('[ActiveRide] finishRide unexpected error: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
-            content: Text('No se pudo finalizar el viaje. Intenta de nuevo.'),
-          ),
+              content: Text('No se pudo finalizar el viaje. Intenta de nuevo.')),
         );
       }
     } finally {

--- a/lib/features/driver/create_ride/create_ride_screen.dart
+++ b/lib/features/driver/create_ride/create_ride_screen.dart
@@ -1,0 +1,375 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../../../core/utils/geocoding_service.dart';
+import '../../../features/auth/auth_viewmodel.dart';
+import '../../../shared/widgets/offline_banner.dart';
+import 'create_ride_viewmodel.dart';
+
+abstract final class _C {
+  static const primary = Color(0xFF1F5DFF);
+  static const background = Color(0xFFFFFFFF);
+  static const textPrimary = Color(0xFF111111);
+  static const muted = Color(0xFF94A3B8);
+  static const cardSurface = Color(0xFFF8FAFC);
+  static const border = Color(0xFFE5E7EB);
+  static const danger = Color(0xFFFF3B30);
+}
+
+class CreateRideScreen extends StatefulWidget {
+  const CreateRideScreen({super.key});
+
+  @override
+  State<CreateRideScreen> createState() => _CreateRideScreenState();
+}
+
+class _CreateRideScreenState extends State<CreateRideScreen> {
+  final _originController = TextEditingController();
+  final _destinationController = TextEditingController();
+
+  @override
+  void dispose() {
+    _originController.dispose();
+    _destinationController.dispose();
+    super.dispose();
+  }
+
+  InputDecoration _fieldDecoration(String hint, IconData icon,
+      {Widget? suffix, String? suffixText}) {
+    return InputDecoration(
+      hintText: hint,
+      hintStyle: GoogleFonts.poppins(color: _C.muted),
+      prefixIcon: Icon(icon, color: _C.muted),
+      suffixIcon: suffix,
+      suffixText: suffixText,
+      suffixStyle: GoogleFonts.poppins(color: _C.muted, fontSize: 13),
+      filled: true,
+      fillColor: _C.cardSurface,
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: const BorderSide(color: _C.border),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: const BorderSide(color: _C.border),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: const BorderSide(color: _C.primary, width: 2),
+      ),
+    );
+  }
+
+  Future<void> _pickDepartureTime(CreateRideViewModel vm) async {
+    final now = DateTime.now();
+    final date = await showDatePicker(
+      context: context,
+      initialDate: now.add(const Duration(hours: 1)),
+      firstDate: now,
+      lastDate: now.add(const Duration(days: 30)),
+    );
+    if (date == null || !mounted) return;
+
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(now.add(const Duration(hours: 1))),
+    );
+    if (time == null) return;
+
+    vm.setDepartureTime(
+        DateTime(date.year, date.month, date.day, time.hour, time.minute));
+  }
+
+  Widget _suggestionList({
+    required List<PlaceSuggestion> suggestions,
+    required void Function(PlaceSuggestion) onSelect,
+    required TextEditingController controller,
+  }) {
+    if (suggestions.isEmpty) return const SizedBox.shrink();
+    return Container(
+      margin: const EdgeInsets.only(top: 2),
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.grey.shade300),
+        borderRadius: BorderRadius.circular(8),
+        color: Colors.white,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.06),
+            blurRadius: 6,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: ListView.builder(
+        shrinkWrap: true,
+        physics: const NeverScrollableScrollPhysics(),
+        itemCount: suggestions.length,
+        itemBuilder: (_, i) {
+          final s = suggestions[i];
+          return ListTile(
+            dense: true,
+            leading:
+                Icon(Icons.location_on, size: 18, color: Colors.grey[500]),
+            title: Text(
+              s.displayName,
+              style: GoogleFonts.poppins(fontSize: 13),
+            ),
+            subtitle: Text(
+              s.fullName.split(',').take(3).join(','),
+              style: GoogleFonts.poppins(
+                  fontSize: 11, color: Colors.grey[600]),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+            onTap: () {
+              onSelect(s);
+              controller.text = s.displayName;
+              FocusScope.of(context).unfocus();
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<CreateRideViewModel>();
+
+    return Scaffold(
+      backgroundColor: _C.background,
+      appBar: AppBar(
+        backgroundColor: _C.background,
+        elevation: 0,
+        title: Text(
+          'Create Ride',
+          style: GoogleFonts.poppins(
+            fontSize: 18,
+            fontWeight: FontWeight.w600,
+            color: _C.textPrimary,
+          ),
+        ),
+        iconTheme: const IconThemeData(color: _C.textPrimary),
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            OfflineBanner(isOffline: vm.isOffline, isFromCache: false),
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    // ── Origin search ───────────────────────────────────
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        TextFormField(
+                          controller: _originController,
+                          style: GoogleFonts.poppins(
+                              fontSize: 14, color: _C.textPrimary),
+                          decoration: _fieldDecoration(
+                            'Search origin...',
+                            Icons.trip_origin,
+                            suffix: vm.isSearchingOrigin
+                                ? const Padding(
+                                    padding: EdgeInsets.all(12),
+                                    child: SizedBox(
+                                      width: 20,
+                                      height: 20,
+                                      child: CircularProgressIndicator(
+                                          strokeWidth: 2),
+                                    ),
+                                  )
+                                : null,
+                          ),
+                          onChanged: (v) {
+                            vm.originLat = null;
+                            vm.searchOrigin(v);
+                          },
+                        ),
+                        _suggestionList(
+                          suggestions: vm.originSuggestions,
+                          onSelect: vm.selectOrigin,
+                          controller: _originController,
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+
+                    // ── Destination search ──────────────────────────────
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        TextFormField(
+                          controller: _destinationController,
+                          style: GoogleFonts.poppins(
+                              fontSize: 14, color: _C.textPrimary),
+                          decoration: _fieldDecoration(
+                            'Search destination...',
+                            Icons.location_on_outlined,
+                            suffix: vm.isSearchingDestination
+                                ? const Padding(
+                                    padding: EdgeInsets.all(12),
+                                    child: SizedBox(
+                                      width: 20,
+                                      height: 20,
+                                      child: CircularProgressIndicator(
+                                          strokeWidth: 2),
+                                    ),
+                                  )
+                                : null,
+                          ),
+                          onChanged: (v) {
+                            vm.destinationLat = null;
+                            vm.searchDestination(v);
+                          },
+                        ),
+                        _suggestionList(
+                          suggestions: vm.destinationSuggestions,
+                          onSelect: vm.selectDestination,
+                          controller: _destinationController,
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+
+                    // ── Departure time ──────────────────────────────────
+                    InkWell(
+                      onTap: () => _pickDepartureTime(vm),
+                      borderRadius: BorderRadius.circular(12),
+                      child: InputDecorator(
+                        decoration: _fieldDecoration(
+                            'Select departure time', Icons.access_time),
+                        child: Text(
+                          vm.departureTime != null
+                              ? DateFormat('MMM d, yyyy – HH:mm')
+                                  .format(vm.departureTime!)
+                              : 'Select departure time',
+                          style: GoogleFonts.poppins(
+                            fontSize: 14,
+                            color: vm.departureTime != null
+                                ? _C.textPrimary
+                                : _C.muted,
+                          ),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+
+                    // ── Seats stepper ───────────────────────────────────
+                    Row(
+                      children: [
+                        Text(
+                          'Seats available',
+                          style: GoogleFonts.poppins(
+                            fontSize: 14,
+                            color: _C.textPrimary,
+                          ),
+                        ),
+                        const Spacer(),
+                        IconButton(
+                          icon: const Icon(Icons.remove_circle_outline),
+                          color: vm.seats == 1 ? _C.muted : _C.primary,
+                          onPressed:
+                              vm.seats == 1 ? null : vm.decrementSeats,
+                        ),
+                        Text(
+                          '${vm.seats}',
+                          style: GoogleFonts.poppins(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w600,
+                            color: _C.textPrimary,
+                          ),
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.add_circle_outline),
+                          color: vm.seats == 6 ? _C.muted : _C.primary,
+                          onPressed:
+                              vm.seats == 6 ? null : vm.incrementSeats,
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+
+                    // ── Price ───────────────────────────────────────────
+                    TextFormField(
+                      keyboardType: TextInputType.number,
+                      style: GoogleFonts.poppins(
+                          fontSize: 14, color: _C.textPrimary),
+                      decoration: _fieldDecoration(
+                          '8000', Icons.attach_money,
+                          suffixText: 'COP'),
+                      onChanged: (v) => vm.price = double.tryParse(v) ?? 0,
+                    ),
+
+                    // ── Error ───────────────────────────────────────────
+                    if (vm.errorMessage != null) ...[
+                      const SizedBox(height: 8),
+                      Text(
+                        vm.errorMessage!,
+                        style: GoogleFonts.poppins(
+                          fontSize: 13,
+                          color: _C.danger,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+
+                    const SizedBox(height: 24),
+
+                    // ── Publish button ──────────────────────────────────
+                    ElevatedButton(
+                      onPressed: vm.isLoading
+                          ? null
+                          : () {
+                              final user = context
+                                  .read<AuthViewModel>()
+                                  .currentUser!;
+                              vm.createRide(
+                                context,
+                                user.id,
+                                user.name,
+                                user.driverRating,
+                              );
+                            },
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: _C.primary,
+                        foregroundColor: _C.background,
+                        disabledBackgroundColor:
+                            _C.primary.withValues(alpha: 0.45),
+                        minimumSize: const Size(double.infinity, 52),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        elevation: 0,
+                        textStyle: GoogleFonts.poppins(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      child: vm.isLoading
+                          ? const SizedBox(
+                              height: 22,
+                              width: 22,
+                              child: CircularProgressIndicator(
+                                color: Colors.white,
+                                strokeWidth: 2.5,
+                              ),
+                            )
+                          : const Text('Publish ride'),
+                    ),
+                    const SizedBox(height: 32),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/driver/create_ride/create_ride_viewmodel.dart
+++ b/lib/features/driver/create_ride/create_ride_viewmodel.dart
@@ -1,0 +1,193 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:cloud_functions/cloud_functions.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/connectivity/connectivity_service.dart';
+import '../../../core/connectivity/sync_manager.dart';
+import '../../../core/location_utils.dart';
+import '../../../core/utils/geocoding_service.dart';
+
+class CreateRideViewModel extends ChangeNotifier {
+  String origin = '';
+  String destination = '';
+  DateTime? departureTime;
+  int seats = 1;
+  double price = 8000;
+  bool isLoading = false;
+  String? errorMessage;
+  bool isOffline = false;
+
+  double? originLat;
+  double? originLng;
+  double? destinationLat;
+  double? destinationLng;
+
+  List<PlaceSuggestion> originSuggestions = [];
+  List<PlaceSuggestion> destinationSuggestions = [];
+  bool isSearchingOrigin = false;
+  bool isSearchingDestination = false;
+
+  StreamSubscription<bool>? _connSub;
+
+  CreateRideViewModel() {
+    _connSub = ConnectivityService().onStatusChanged.listen((online) {
+      isOffline = !online;
+      notifyListeners();
+    });
+  }
+
+  // ── Search ────────────────────────────────────────────────────────────────
+
+  Future<void> searchOrigin(String query) async {
+    isSearchingOrigin = true;
+    notifyListeners();
+    originSuggestions = await GeocodingService.searchPlaces(query);
+    isSearchingOrigin = false;
+    notifyListeners();
+  }
+
+  Future<void> searchDestination(String query) async {
+    isSearchingDestination = true;
+    notifyListeners();
+    destinationSuggestions = await GeocodingService.searchPlaces(query);
+    isSearchingDestination = false;
+    notifyListeners();
+  }
+
+  void selectOrigin(PlaceSuggestion place) {
+    origin = place.displayName;
+    originLat = place.lat;
+    originLng = place.lon;
+    originSuggestions = [];
+    notifyListeners();
+  }
+
+  void selectDestination(PlaceSuggestion place) {
+    destination = place.displayName;
+    destinationLat = place.lat;
+    destinationLng = place.lon;
+    destinationSuggestions = [];
+    notifyListeners();
+  }
+
+  // ── Stepper helpers ───────────────────────────────────────────────────────
+
+  void setDepartureTime(DateTime value) {
+    departureTime = value;
+    notifyListeners();
+  }
+
+  void incrementSeats() {
+    if (seats < 6) {
+      seats++;
+      notifyListeners();
+    }
+  }
+
+  void decrementSeats() {
+    if (seats > 1) {
+      seats--;
+      notifyListeners();
+    }
+  }
+
+  // ── Validation ────────────────────────────────────────────────────────────
+
+  String? validateForm() {
+    if (origin.trim().isEmpty) return 'Origin is required';
+    if (originLat == null) {
+      return 'Select a valid origin from the suggestions';
+    }
+    if (destination.trim().isEmpty) return 'Destination is required';
+    if (destinationLat == null) {
+      return 'Select a valid destination from the suggestions';
+    }
+    if (departureTime == null) return 'Departure time is required';
+    if (departureTime!.isBefore(DateTime.now())) {
+      return 'Departure time must be in the future';
+    }
+    if (seats < 1 || seats > 6) return 'Seats must be between 1 and 6';
+    if (price < 1000) return 'Price must be at least \$1,000';
+    return null;
+  }
+
+  // ── Create ────────────────────────────────────────────────────────────────
+
+  Future<void> createRide(
+    BuildContext context,
+    String userId,
+    String driverName,
+    double driverRating,
+  ) async {
+    final error = validateForm();
+    if (error != null) {
+      errorMessage = error;
+      notifyListeners();
+      return;
+    }
+
+    isLoading = true;
+    errorMessage = null;
+    notifyListeners();
+
+    try {
+      final zone =
+          LocationUtils.zoneFromLatLon(originLat!, originLng!) ?? 'Bogotá';
+
+      final payload = {
+        'origin': origin.trim(),
+        'destination': destination.trim(),
+        'originLat': originLat,
+        'originLng': originLng,
+        'destinationLat': destinationLat,
+        'destinationLng': destinationLng,
+        'zone': zone,
+        'driverId': userId,
+        'driverName': driverName,
+        'driverRating': driverRating,
+        'seatsAvailable': seats,
+        'price': price,
+        'departureTime': departureTime!.millisecondsSinceEpoch,
+      };
+
+      debugPrint('[CreateRide] payload: $payload');
+
+      if (isOffline) {
+        await SyncManager().enqueue('create_ride', jsonEncode(payload));
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text(
+                  'Ride saved offline — will publish when you reconnect'),
+            ),
+          );
+          context.go('/driver/my-rides');
+        }
+        return;
+      }
+
+      final cf = FirebaseFunctions.instance.httpsCallable('createRide');
+      final result = await cf.call(payload);
+      debugPrint('[CreateRide] CF result: ${result.data}');
+
+      if (context.mounted) {
+        context.go('/driver/my-rides');
+      }
+    } catch (e) {
+      debugPrint('[CreateRide] CF error details: ${e.runtimeType}: $e');
+      errorMessage = 'Failed to create ride. Please try again.';
+    } finally {
+      isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  @override
+  void dispose() {
+    _connSub?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/features/driver/create_ride/create_ride_viewmodel.dart
+++ b/lib/features/driver/create_ride/create_ride_viewmodel.dart
@@ -31,6 +31,8 @@ class CreateRideViewModel extends ChangeNotifier {
   bool isSearchingDestination = false;
 
   StreamSubscription<bool>? _connSub;
+  Timer? _originDebounce;
+  Timer? _destinationDebounce;
 
   CreateRideViewModel() {
     _connSub = ConnectivityService().onStatusChanged.listen((online) {
@@ -41,20 +43,38 @@ class CreateRideViewModel extends ChangeNotifier {
 
   // ── Search ────────────────────────────────────────────────────────────────
 
-  Future<void> searchOrigin(String query) async {
+  void searchOrigin(String query) {
+    _originDebounce?.cancel();
+    if (query.trim().length < 3) {
+      originSuggestions = [];
+      isSearchingOrigin = false;
+      notifyListeners();
+      return;
+    }
     isSearchingOrigin = true;
     notifyListeners();
-    originSuggestions = await GeocodingService.searchPlaces(query);
-    isSearchingOrigin = false;
-    notifyListeners();
+    _originDebounce = Timer(const Duration(milliseconds: 400), () async {
+      originSuggestions = await GeocodingService.searchPlaces(query);
+      isSearchingOrigin = false;
+      notifyListeners();
+    });
   }
 
-  Future<void> searchDestination(String query) async {
+  void searchDestination(String query) {
+    _destinationDebounce?.cancel();
+    if (query.trim().length < 3) {
+      destinationSuggestions = [];
+      isSearchingDestination = false;
+      notifyListeners();
+      return;
+    }
     isSearchingDestination = true;
     notifyListeners();
-    destinationSuggestions = await GeocodingService.searchPlaces(query);
-    isSearchingDestination = false;
-    notifyListeners();
+    _destinationDebounce = Timer(const Duration(milliseconds: 400), () async {
+      destinationSuggestions = await GeocodingService.searchPlaces(query);
+      isSearchingDestination = false;
+      notifyListeners();
+    });
   }
 
   void selectOrigin(PlaceSuggestion place) {
@@ -169,7 +189,8 @@ class CreateRideViewModel extends ChangeNotifier {
         return;
       }
 
-      final cf = FirebaseFunctions.instance.httpsCallable('createRide');
+      final cf = FirebaseFunctions.instanceFor(region: 'us-central1')
+          .httpsCallable('createRide');
       final result = await cf.call(payload);
       debugPrint('[CreateRide] CF result: ${result.data}');
 
@@ -188,6 +209,8 @@ class CreateRideViewModel extends ChangeNotifier {
   @override
   void dispose() {
     _connSub?.cancel();
+    _originDebounce?.cancel();
+    _destinationDebounce?.cancel();
     super.dispose();
   }
 }

--- a/lib/features/driver/my_rides/driver_ride_detail_screen.dart
+++ b/lib/features/driver/my_rides/driver_ride_detail_screen.dart
@@ -313,6 +313,43 @@ class _DetailView extends StatelessWidget {
               style: GoogleFonts.poppins(fontSize: 13, color: _C.red),
             ),
           ],
+
+          if (vm.canEdit) ...[
+            const SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              height: 52,
+              child: ElevatedButton.icon(
+                icon: const Icon(Icons.play_arrow_rounded, color: Colors.white),
+                label: Text(
+                  'Start Ride',
+                  style: GoogleFonts.poppins(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                    color: Colors.white,
+                  ),
+                ),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: _C.green,
+                  elevation: 0,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                onPressed: vm.isLoading
+                    ? null
+                    : () async {
+                        final started = await vm.startRide();
+                        if (started && context.mounted) {
+                          context.pushReplacement(
+                            '/driver/active-ride',
+                            extra: {'rideId': vm.ride.id},
+                          );
+                        }
+                      },
+              ),
+            ),
+          ],
         ],
       ),
     );

--- a/lib/features/driver/my_rides/driver_ride_detail_screen.dart
+++ b/lib/features/driver/my_rides/driver_ride_detail_screen.dart
@@ -50,6 +50,20 @@ class DriverRideDetailScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final vm = context.watch<DriverRideDetailViewModel>();
 
+    // Navigate to active ride as soon as status flips to in_progress.
+    // Done here (not inside _DetailView) because _DetailView is swapped
+    // for a spinner while isLoading=true, making its context unmounted.
+    if (vm.ride.status == 'in_progress' && !vm.isLoading) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (context.mounted) {
+          context.pushReplacement(
+            '/driver/active-ride',
+            extra: {'rideId': vm.ride.id},
+          );
+        }
+      });
+    }
+
     return PopScope(
       canPop: !vm.isEditing,
       onPopInvokedWithResult: (didPop, _) {
@@ -316,37 +330,49 @@ class _DetailView extends StatelessWidget {
 
           if (vm.canEdit) ...[
             const SizedBox(height: 24),
+            if (vm.startRideHint != null) ...[
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(Icons.schedule, size: 14, color: _C.muted),
+                  const SizedBox(width: 4),
+                  Text(
+                    vm.startRideHint!,
+                    style: GoogleFonts.poppins(
+                      fontSize: 12,
+                      color: _C.muted,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+            ],
             SizedBox(
               width: double.infinity,
               height: 52,
               child: ElevatedButton.icon(
-                icon: const Icon(Icons.play_arrow_rounded, color: Colors.white),
+                icon: Icon(
+                  Icons.play_arrow_rounded,
+                  color: vm.canStart ? Colors.white : _C.muted,
+                ),
                 label: Text(
                   'Start Ride',
                   style: GoogleFonts.poppins(
                     fontSize: 15,
                     fontWeight: FontWeight.w600,
-                    color: Colors.white,
+                    color: vm.canStart ? Colors.white : _C.muted,
                   ),
                 ),
                 style: ElevatedButton.styleFrom(
-                  backgroundColor: _C.green,
+                  backgroundColor: vm.canStart ? _C.green : _C.border,
                   elevation: 0,
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12),
                   ),
                 ),
-                onPressed: vm.isLoading
+                onPressed: (vm.isLoading || !vm.canStart)
                     ? null
-                    : () async {
-                        final started = await vm.startRide();
-                        if (started && context.mounted) {
-                          context.pushReplacement(
-                            '/driver/active-ride',
-                            extra: {'rideId': vm.ride.id},
-                          );
-                        }
-                      },
+                    : () => vm.startRide(),
               ),
             ),
           ],

--- a/lib/features/driver/my_rides/driver_ride_detail_screen.dart
+++ b/lib/features/driver/my_rides/driver_ride_detail_screen.dart
@@ -1,0 +1,748 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:provider/provider.dart';
+
+import 'driver_ride_detail_viewmodel.dart';
+
+abstract final class _C {
+  static const primary = Color(0xFF1F5DFF);
+  static const background = Color(0xFFFFFFFF);
+  static const textPrimary = Color(0xFF111111);
+  static const textSecondary = Color(0xFF555555);
+  static const muted = Color(0xFF94A3B8);
+  static const border = Color(0xFFE5E7EB);
+  static const cardSurface = Color(0xFFF8FAFC);
+  static const green = Color(0xFF16A34A);
+  static const blue = Color(0xFF2563EB);
+  static const orange = Color(0xFFF97316);
+  static const grey = Color(0xFF9CA3AF);
+  static const red = Color(0xFFDC2626);
+}
+
+String _fmtTime(DateTime dt) {
+  final h = dt.hour > 12 ? dt.hour - 12 : (dt.hour == 0 ? 12 : dt.hour);
+  final m = dt.minute.toString().padLeft(2, '0');
+  final p = dt.hour >= 12 ? 'PM' : 'AM';
+  return '$h:$m $p';
+}
+
+String _fmtDate(DateTime dt) {
+  const months = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ];
+  return '${months[dt.month - 1]} ${dt.day}, ${dt.year}';
+}
+
+String _fmtPrice(double p) {
+  final n = p.toInt();
+  if (n >= 1000) {
+    return '\$${n ~/ 1000}.${(n % 1000).toString().padLeft(3, '0')}';
+  }
+  return '\$$n';
+}
+
+class DriverRideDetailScreen extends StatelessWidget {
+  const DriverRideDetailScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<DriverRideDetailViewModel>();
+
+    return PopScope(
+      canPop: !vm.isEditing,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop && vm.isEditing) vm.cancelEditing();
+      },
+      child: Scaffold(
+        backgroundColor: _C.background,
+        appBar: _buildAppBar(context, vm),
+        body: SafeArea(
+          child: vm.isLoading
+              ? const Center(child: CircularProgressIndicator())
+              : vm.isEditing
+                  ? _EditForm(vm: vm)
+                  : _DetailView(vm: vm),
+        ),
+      ),
+    );
+  }
+
+  AppBar _buildAppBar(BuildContext context, DriverRideDetailViewModel vm) {
+    if (vm.isEditing) {
+      return AppBar(
+        backgroundColor: _C.background,
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.close, color: _C.textPrimary),
+          onPressed: vm.cancelEditing,
+        ),
+        title: Text(
+          'Edit Ride',
+          style: GoogleFonts.poppins(
+            fontSize: 18,
+            fontWeight: FontWeight.w600,
+            color: _C.textPrimary,
+          ),
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.check, color: _C.primary),
+            onPressed: () async {
+              final saved = await vm.saveChanges();
+              if (saved && context.mounted) context.pop(true);
+            },
+          ),
+        ],
+      );
+    }
+
+    return AppBar(
+      backgroundColor: _C.background,
+      elevation: 0,
+      scrolledUnderElevation: 0,
+      leading: IconButton(
+        icon: const Icon(Icons.arrow_back_ios_new, color: _C.textPrimary),
+        onPressed: () => context.pop(),
+      ),
+      title: Text(
+        'Ride Detail',
+        style: GoogleFonts.poppins(
+          fontSize: 18,
+          fontWeight: FontWeight.w600,
+          color: _C.textPrimary,
+        ),
+      ),
+      actions: [
+        if (vm.canEdit) ...[
+          IconButton(
+            icon: const Icon(Icons.edit_outlined, color: _C.primary),
+            onPressed: vm.startEditing,
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete_outline, color: _C.red),
+            onPressed: () => _showDeleteDialog(context, vm),
+          ),
+        ],
+      ],
+    );
+  }
+
+  void _showDeleteDialog(BuildContext context, DriverRideDetailViewModel vm) {
+    showDialog<void>(
+      context: context,
+      builder: (dialogCtx) => AlertDialog(
+        title: Text(
+          'Delete Ride',
+          style: GoogleFonts.poppins(fontWeight: FontWeight.w600),
+        ),
+        content: Text(
+          'Are you sure you want to delete this ride? This action cannot be undone.',
+          style: GoogleFonts.poppins(fontSize: 14, color: _C.textSecondary),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogCtx).pop(),
+            child: Text(
+              'Cancel',
+              style: GoogleFonts.poppins(color: _C.textSecondary),
+            ),
+          ),
+          TextButton(
+            onPressed: () async {
+              Navigator.of(dialogCtx).pop();
+              final deleted = await vm.deleteRide();
+              if (deleted && context.mounted) context.pop(true);
+            },
+            child: Text(
+              'Delete',
+              style: GoogleFonts.poppins(
+                color: _C.red,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Detail view ───────────────────────────────────────────────────────────────
+
+class _DetailView extends StatelessWidget {
+  const _DetailView({required this.vm});
+
+  final DriverRideDetailViewModel vm;
+
+  @override
+  Widget build(BuildContext context) {
+    final ride = vm.ride;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Route card
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(20),
+            decoration: BoxDecoration(
+              color: _C.cardSurface,
+              borderRadius: BorderRadius.circular(16),
+              border: Border.all(color: _C.border),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _RouteStop(label: ride.origin, isOrigin: true),
+                Padding(
+                  padding: const EdgeInsets.only(left: 7),
+                  child: Container(
+                    width: 2,
+                    height: 24,
+                    color: _C.border,
+                  ),
+                ),
+                _RouteStop(label: ride.destination, isOrigin: false),
+              ],
+            ),
+          ),
+
+          const SizedBox(height: 16),
+
+          // Trip details card
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(20),
+            decoration: BoxDecoration(
+              color: _C.background,
+              borderRadius: BorderRadius.circular(16),
+              border: Border.all(color: _C.border),
+              boxShadow: const [
+                BoxShadow(
+                  offset: Offset(0, 2),
+                  blurRadius: 8,
+                  color: Color(0x0A000000),
+                ),
+              ],
+            ),
+            child: Column(
+              children: [
+                _InfoRow(
+                  icon: Icons.calendar_today_outlined,
+                  label: 'Date',
+                  value: _fmtDate(ride.departureTime),
+                ),
+                const _Divider(),
+                _InfoRow(
+                  icon: Icons.access_time_outlined,
+                  label: 'Departure',
+                  value: _fmtTime(ride.departureTime),
+                ),
+                const _Divider(),
+                _InfoRow(
+                  icon: Icons.event_seat_outlined,
+                  label: 'Seats available',
+                  value: ride.seatsAvailable.toString(),
+                ),
+                const _Divider(),
+                _InfoRow(
+                  icon: Icons.attach_money_outlined,
+                  label: 'Price',
+                  value: '${_fmtPrice(ride.price)} COP',
+                ),
+              ],
+            ),
+          ),
+
+          const SizedBox(height: 16),
+
+          // Status card
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(20),
+            decoration: BoxDecoration(
+              color: _C.background,
+              borderRadius: BorderRadius.circular(16),
+              border: Border.all(color: _C.border),
+              boxShadow: const [
+                BoxShadow(
+                  offset: Offset(0, 2),
+                  blurRadius: 8,
+                  color: Color(0x0A000000),
+                ),
+              ],
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Status',
+                  style: GoogleFonts.poppins(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: _C.textSecondary,
+                  ),
+                ),
+                const SizedBox(height: 10),
+                _StatusChip(status: ride.status),
+                if (!vm.canEdit) ...[
+                  const SizedBox(height: 12),
+                  Text(
+                    ride.status == 'in_progress'
+                        ? 'This ride is currently in progress and cannot be modified.'
+                        : 'This ride has been completed and cannot be modified.',
+                    style: GoogleFonts.poppins(
+                      fontSize: 12,
+                      color: _C.muted,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+
+          if (vm.errorMessage != null) ...[
+            const SizedBox(height: 12),
+            Text(
+              vm.errorMessage!,
+              style: GoogleFonts.poppins(fontSize: 13, color: _C.red),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _RouteStop extends StatelessWidget {
+  const _RouteStop({required this.label, required this.isOrigin});
+
+  final String label;
+  final bool isOrigin;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Container(
+          width: 16,
+          height: 16,
+          decoration: BoxDecoration(
+            color: isOrigin ? _C.primary : _C.textPrimary,
+            shape: BoxShape.circle,
+          ),
+          child: isOrigin
+              ? null
+              : const Icon(Icons.location_on, size: 10, color: Colors.white),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Text(
+            label,
+            style: GoogleFonts.poppins(
+              fontSize: 15,
+              fontWeight: FontWeight.w600,
+              color: _C.textPrimary,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        children: [
+          Icon(icon, size: 18, color: _C.muted),
+          const SizedBox(width: 12),
+          Text(
+            label,
+            style: GoogleFonts.poppins(fontSize: 13, color: _C.textSecondary),
+          ),
+          const Spacer(),
+          Text(
+            value,
+            style: GoogleFonts.poppins(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+              color: _C.textPrimary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Divider extends StatelessWidget {
+  const _Divider();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Divider(color: _C.border, height: 1);
+  }
+}
+
+// ── Edit form ─────────────────────────────────────────────────────────────────
+
+class _EditForm extends StatelessWidget {
+  const _EditForm({required this.vm});
+
+  final DriverRideDetailViewModel vm;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _SectionLabel('Origin'),
+          const SizedBox(height: 6),
+          _StyledTextField(
+            controller: vm.originCtrl,
+            hint: 'Enter origin',
+          ),
+          const SizedBox(height: 16),
+
+          _SectionLabel('Destination'),
+          const SizedBox(height: 6),
+          _StyledTextField(
+            controller: vm.destCtrl,
+            hint: 'Enter destination',
+          ),
+          const SizedBox(height: 16),
+
+          _SectionLabel('Departure date & time'),
+          const SizedBox(height: 6),
+          _DateTimePicker(vm: vm),
+          const SizedBox(height: 16),
+
+          _SectionLabel('Seats available'),
+          const SizedBox(height: 6),
+          _SeatsStepper(vm: vm),
+          const SizedBox(height: 16),
+
+          _SectionLabel('Price (COP)'),
+          const SizedBox(height: 6),
+          _StyledTextField(
+            controller: vm.priceCtrl,
+            hint: 'e.g. 8000',
+            keyboardType: TextInputType.number,
+          ),
+
+          if (vm.errorMessage != null) ...[
+            const SizedBox(height: 12),
+            Text(
+              vm.errorMessage!,
+              style: GoogleFonts.poppins(fontSize: 13, color: _C.red),
+            ),
+          ],
+
+          const SizedBox(height: 24),
+
+          SizedBox(
+            width: double.infinity,
+            height: 52,
+            child: ElevatedButton(
+              onPressed: () async {
+                final saved = await vm.saveChanges();
+                if (saved && context.mounted) context.pop(true);
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: _C.primary,
+                foregroundColor: Colors.white,
+                elevation: 0,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              child: Text(
+                'Save Changes',
+                style: GoogleFonts.poppins(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ),
+
+          const SizedBox(height: 12),
+
+          SizedBox(
+            width: double.infinity,
+            child: TextButton(
+              onPressed: vm.cancelEditing,
+              child: Text(
+                'Cancel',
+                style: GoogleFonts.poppins(
+                  fontSize: 14,
+                  color: _C.textSecondary,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: GoogleFonts.poppins(
+        fontSize: 13,
+        fontWeight: FontWeight.w600,
+        color: _C.textSecondary,
+      ),
+    );
+  }
+}
+
+class _StyledTextField extends StatelessWidget {
+  const _StyledTextField({
+    required this.controller,
+    required this.hint,
+    this.keyboardType,
+  });
+
+  final TextEditingController controller;
+  final String hint;
+  final TextInputType? keyboardType;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      keyboardType: keyboardType,
+      style: GoogleFonts.poppins(fontSize: 14, color: _C.textPrimary),
+      decoration: InputDecoration(
+        hintText: hint,
+        hintStyle: GoogleFonts.poppins(fontSize: 14, color: _C.muted),
+        filled: true,
+        fillColor: _C.cardSurface,
+        contentPadding:
+            const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: const BorderSide(color: _C.border),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: const BorderSide(color: _C.border),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: const BorderSide(color: _C.primary),
+        ),
+      ),
+    );
+  }
+}
+
+class _DateTimePicker extends StatelessWidget {
+  const _DateTimePicker({required this.vm});
+
+  final DriverRideDetailViewModel vm;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () => _pick(context),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
+        decoration: BoxDecoration(
+          color: _C.cardSurface,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: _C.border),
+        ),
+        child: Row(
+          children: [
+            const Icon(Icons.calendar_today_outlined, size: 18, color: _C.muted),
+            const SizedBox(width: 10),
+            Text(
+              '${_fmtDate(vm.editTime)} · ${_fmtTime(vm.editTime)}',
+              style: GoogleFonts.poppins(fontSize: 14, color: _C.textPrimary),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _pick(BuildContext context) async {
+    final now = DateTime.now();
+    final date = await showDatePicker(
+      context: context,
+      initialDate: vm.editTime.isAfter(now) ? vm.editTime : now,
+      firstDate: now,
+      lastDate: now.add(const Duration(days: 365)),
+    );
+    if (date == null || !context.mounted) return;
+
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(vm.editTime),
+    );
+    if (time == null) return;
+
+    vm.setEditTime(
+      DateTime(date.year, date.month, date.day, time.hour, time.minute),
+    );
+  }
+}
+
+class _SeatsStepper extends StatelessWidget {
+  const _SeatsStepper({required this.vm});
+
+  final DriverRideDetailViewModel vm;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: _C.cardSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: _C.border),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.event_seat_outlined, size: 18, color: _C.muted),
+          const SizedBox(width: 10),
+          Text(
+            'Seats',
+            style: GoogleFonts.poppins(fontSize: 14, color: _C.textPrimary),
+          ),
+          const Spacer(),
+          _StepperButton(
+            icon: Icons.remove,
+            onTap: vm.decrementSeats,
+            enabled: vm.editSeats > 1,
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Text(
+              '${vm.editSeats}',
+              style: GoogleFonts.poppins(
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+                color: _C.textPrimary,
+              ),
+            ),
+          ),
+          _StepperButton(
+            icon: Icons.add,
+            onTap: vm.incrementSeats,
+            enabled: vm.editSeats < 6,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StepperButton extends StatelessWidget {
+  const _StepperButton({
+    required this.icon,
+    required this.onTap,
+    required this.enabled,
+  });
+
+  final IconData icon;
+  final VoidCallback onTap;
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: enabled ? onTap : null,
+      child: Container(
+        width: 32,
+        height: 32,
+        decoration: BoxDecoration(
+          color: enabled ? _C.primary : _C.border,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Icon(icon, size: 18, color: Colors.white),
+      ),
+    );
+  }
+}
+
+class _StatusChip extends StatelessWidget {
+  const _StatusChip({required this.status});
+
+  final String status;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color bg;
+    final Color fg;
+    final String label;
+
+    switch (status) {
+      case 'available':
+      case 'active':
+        bg = const Color(0xFFDCFCE7);
+        fg = _C.green;
+        label = status == 'active' ? 'Active' : 'Available';
+      case 'in_progress':
+        bg = const Color(0xFFDBEAFE);
+        fg = _C.blue;
+        label = 'In Progress';
+      case 'completed':
+        bg = const Color(0xFFF3F4F6);
+        fg = _C.grey;
+        label = 'Completed';
+      default:
+        bg = const Color(0xFFFED7AA);
+        fg = _C.orange;
+        label = 'Pending';
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Text(
+        label,
+        style: GoogleFonts.poppins(
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          color: fg,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/driver/my_rides/driver_ride_detail_viewmodel.dart
+++ b/lib/features/driver/my_rides/driver_ride_detail_viewmodel.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+
+import '../../../data/models/ride_model.dart';
+import '../../../data/repositories/impl/firebase_ride_repository.dart';
+
+class DriverRideDetailViewModel extends ChangeNotifier {
+  DriverRideDetailViewModel(RideModel ride, this._repository)
+      : _ride = ride {
+    _originCtrl = TextEditingController(text: ride.origin);
+    _destCtrl = TextEditingController(text: ride.destination);
+    _priceCtrl = TextEditingController(text: ride.price.toInt().toString());
+    _editTime = ride.departureTime;
+    _editSeats = ride.seatsAvailable;
+  }
+
+  RideModel _ride;
+  final FirebaseRideRepository _repository;
+
+  late final TextEditingController _originCtrl;
+  late final TextEditingController _destCtrl;
+  late final TextEditingController _priceCtrl;
+  late DateTime _editTime;
+  late int _editSeats;
+
+  bool isEditing = false;
+  bool isLoading = false;
+  String? errorMessage;
+
+  RideModel get ride => _ride;
+  TextEditingController get originCtrl => _originCtrl;
+  TextEditingController get destCtrl => _destCtrl;
+  TextEditingController get priceCtrl => _priceCtrl;
+  DateTime get editTime => _editTime;
+  int get editSeats => _editSeats;
+
+  bool get canEdit => _ride.status == 'available' || _ride.status == 'active';
+
+  void startEditing() {
+    _originCtrl.text = _ride.origin;
+    _destCtrl.text = _ride.destination;
+    _priceCtrl.text = _ride.price.toInt().toString();
+    _editTime = _ride.departureTime;
+    _editSeats = _ride.seatsAvailable;
+    isEditing = true;
+    errorMessage = null;
+    notifyListeners();
+  }
+
+  void cancelEditing() {
+    isEditing = false;
+    errorMessage = null;
+    notifyListeners();
+  }
+
+  void setEditTime(DateTime dt) {
+    _editTime = dt;
+    notifyListeners();
+  }
+
+  void incrementSeats() {
+    if (_editSeats < 6) {
+      _editSeats++;
+      notifyListeners();
+    }
+  }
+
+  void decrementSeats() {
+    if (_editSeats > 1) {
+      _editSeats--;
+      notifyListeners();
+    }
+  }
+
+  String? _validate() {
+    if (_originCtrl.text.trim().isEmpty) return 'Origin is required';
+    if (_destCtrl.text.trim().isEmpty) return 'Destination is required';
+    if (_editTime.isBefore(DateTime.now())) {
+      return 'Departure time must be in the future';
+    }
+    final price = double.tryParse(_priceCtrl.text.replaceAll(',', ''));
+    if (price == null || price < 1000) {
+      return 'Price must be at least \$1,000';
+    }
+    return null;
+  }
+
+  Future<bool> saveChanges() async {
+    final err = _validate();
+    if (err != null) {
+      errorMessage = err;
+      notifyListeners();
+      return false;
+    }
+
+    isLoading = true;
+    errorMessage = null;
+    notifyListeners();
+
+    try {
+      final price = double.parse(_priceCtrl.text.replaceAll(',', ''));
+      await _repository.updateRide(
+        rideId: _ride.id,
+        origin: _originCtrl.text.trim(),
+        destination: _destCtrl.text.trim(),
+        departureTime: _editTime,
+        seatsAvailable: _editSeats,
+        price: price,
+      );
+      _ride = _ride.copyWith(
+        origin: _originCtrl.text.trim(),
+        destination: _destCtrl.text.trim(),
+        departureTime: _editTime,
+        seatsAvailable: _editSeats,
+        price: price,
+      );
+      isEditing = false;
+      return true;
+    } catch (e) {
+      debugPrint('[RideDetail] updateRide error: $e');
+      errorMessage = 'Failed to update ride. Please try again.';
+      return false;
+    } finally {
+      isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<bool> deleteRide() async {
+    isLoading = true;
+    errorMessage = null;
+    notifyListeners();
+
+    try {
+      await _repository.deleteRide(_ride.id);
+      return true;
+    } catch (e) {
+      debugPrint('[RideDetail] deleteRide error: $e');
+      errorMessage = 'Failed to delete ride. Please try again.';
+      return false;
+    } finally {
+      isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  @override
+  void dispose() {
+    _originCtrl.dispose();
+    _destCtrl.dispose();
+    _priceCtrl.dispose();
+    super.dispose();
+  }
+}

--- a/lib/features/driver/my_rides/driver_ride_detail_viewmodel.dart
+++ b/lib/features/driver/my_rides/driver_ride_detail_viewmodel.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_functions/cloud_functions.dart';
 import 'package:flutter/material.dart';
 
 import '../../../data/models/ride_model.dart';
@@ -118,6 +119,27 @@ class DriverRideDetailViewModel extends ChangeNotifier {
     } catch (e) {
       debugPrint('[RideDetail] updateRide error: $e');
       errorMessage = 'Failed to update ride. Please try again.';
+      return false;
+    } finally {
+      isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<bool> startRide() async {
+    isLoading = true;
+    errorMessage = null;
+    notifyListeners();
+
+    try {
+      await FirebaseFunctions.instance
+          .httpsCallable('startRide')
+          .call({'rideId': _ride.id});
+      _ride = _ride.copyWith(status: 'in_progress');
+      return true;
+    } catch (e) {
+      debugPrint('[RideDetail] startRide error: $e');
+      errorMessage = 'Failed to start ride. Please try again.';
       return false;
     } finally {
       isLoading = false;

--- a/lib/features/driver/my_rides/driver_ride_detail_viewmodel.dart
+++ b/lib/features/driver/my_rides/driver_ride_detail_viewmodel.dart
@@ -36,6 +36,27 @@ class DriverRideDetailViewModel extends ChangeNotifier {
 
   bool get canEdit => _ride.status == 'available' || _ride.status == 'active';
 
+  // True only within the 30-min-before to 15-min-after window
+  bool get canStart {
+    if (!canEdit) return false;
+    final now = DateTime.now();
+    final windowOpen = _ride.departureTime.subtract(const Duration(minutes: 30));
+    final windowClose = _ride.departureTime.add(const Duration(minutes: 15));
+    return now.isAfter(windowOpen) && now.isBefore(windowClose);
+  }
+
+  // Hint shown when canEdit but canStart is false (too early)
+  String? get startRideHint {
+    if (!canEdit) return null;
+    final now = DateTime.now();
+    final windowOpen = _ride.departureTime.subtract(const Duration(minutes: 30));
+    if (now.isBefore(windowOpen)) {
+      final mins = windowOpen.difference(now).inMinutes + 1;
+      return 'Podrás iniciar el viaje en $mins min';
+    }
+    return null;
+  }
+
   void startEditing() {
     _originCtrl.text = _ride.origin;
     _destCtrl.text = _ride.destination;

--- a/lib/features/driver/my_rides/my_rides_screen.dart
+++ b/lib/features/driver/my_rides/my_rides_screen.dart
@@ -1,0 +1,411 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:provider/provider.dart';
+
+import '../../../data/models/ride_model.dart';
+import '../../../shared/widgets/offline_banner.dart';
+import 'my_rides_viewmodel.dart';
+
+// ── Colour palette ────────────────────────────────────────────────────────────
+abstract final class _Colors {
+  static const primary = Color(0xFF1F5DFF);
+  static const background = Color(0xFFFFFFFF);
+  static const textPrimary = Color(0xFF111111);
+  static const textSecondary = Color(0xFF555555);
+  static const muted = Color(0xFF94A3B8);
+  static const border = Color(0xFFE5E7EB);
+  static const green = Color(0xFF16A34A);
+  static const blue = Color(0xFF2563EB);
+  static const orange = Color(0xFFF97316);
+  static const grey = Color(0xFF9CA3AF);
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+String _fmtTime(DateTime dt) {
+  final h = dt.hour > 12 ? dt.hour - 12 : (dt.hour == 0 ? 12 : dt.hour);
+  final m = dt.minute.toString().padLeft(2, '0');
+  final p = dt.hour >= 12 ? 'PM' : 'AM';
+  return '$h:$m $p';
+}
+
+String _fmtPrice(double p) {
+  final n = p.toInt();
+  if (n >= 1000) {
+    return '\$${n ~/ 1000}.${(n % 1000).toString().padLeft(3, '0')}';
+  }
+  return '\$$n';
+}
+
+// ── Screen ────────────────────────────────────────────────────────────────────
+class MyRidesScreen extends StatefulWidget {
+  const MyRidesScreen({super.key});
+
+  @override
+  State<MyRidesScreen> createState() => _MyRidesScreenState();
+}
+
+class _MyRidesScreenState extends State<MyRidesScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final uid = FirebaseAuth.instance.currentUser?.uid;
+      if (uid != null && mounted) {
+        context.read<MyRidesViewModel>().loadRides(uid);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<MyRidesViewModel>();
+
+    return Scaffold(
+      backgroundColor: _Colors.background,
+      appBar: AppBar(
+        backgroundColor: _Colors.background,
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios_new, color: _Colors.textPrimary),
+          onPressed: () => context.go('/home'),
+        ),
+        title: Text(
+          'My Rides',
+          style: GoogleFonts.poppins(
+            fontSize: 18,
+            fontWeight: FontWeight.w600,
+            color: _Colors.textPrimary,
+          ),
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add, color: _Colors.primary),
+            onPressed: () => context.push('/driver/create-ride'),
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            OfflineBanner(
+              isOffline: vm.isOffline,
+              isFromCache: vm.isFromCache,
+            ),
+            Expanded(
+              child: _buildBody(vm),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBody(MyRidesViewModel vm) {
+    if (vm.isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (vm.rides.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.directions_car_outlined,
+              size: 64,
+              color: _Colors.grey,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'No rides published yet',
+              style: GoogleFonts.poppins(
+                fontSize: 15,
+                color: _Colors.textSecondary,
+              ),
+            ),
+            const SizedBox(height: 16),
+            SizedBox(
+              width: 200,
+              height: 44,
+              child: ElevatedButton(
+                onPressed: () => context.push('/driver/create-ride'),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: _Colors.primary,
+                  foregroundColor: Colors.white,
+                  elevation: 0,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                child: Text(
+                  'Create your first ride',
+                  style: GoogleFonts.poppins(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return ListView.separated(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      itemCount: vm.rides.length,
+      separatorBuilder: (context, index) => const SizedBox(height: 10),
+      itemBuilder: (_, i) => _RideDriverCard(ride: vm.rides[i]),
+    );
+  }
+}
+
+// ── Card ──────────────────────────────────────────────────────────────────────
+class _RideDriverCard extends StatelessWidget {
+  const _RideDriverCard({required this.ride});
+
+  final RideModel ride;
+
+  @override
+  Widget build(BuildContext context) {
+    final isPending = ride.status == 'pending';
+    final canNavigate = !isPending;
+    final showActiveRide =
+        ride.status == 'available' || ride.status == 'in_progress';
+
+    return GestureDetector(
+      onTap: () async {
+        final result = await context.push<bool>(
+          '/driver/my-rides/${ride.id}',
+          extra: ride,
+        );
+        if ((result ?? false) && context.mounted) {
+          final uid = FirebaseAuth.instance.currentUser?.uid;
+          if (uid != null) {
+            context.read<MyRidesViewModel>().loadRides(uid);
+          }
+        }
+      },
+      child: Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: _Colors.background,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: _Colors.border),
+        boxShadow: const [
+          BoxShadow(offset: Offset(0, 2), blurRadius: 8, color: Color(0x0A000000)),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Route row
+          Row(
+            children: [
+              Container(
+                width: 8,
+                height: 8,
+                decoration: const BoxDecoration(
+                  color: _Colors.primary,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  ride.origin,
+                  style: GoogleFonts.poppins(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                    color: _Colors.textPrimary,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 8),
+                child: Icon(Icons.arrow_forward, size: 14, color: _Colors.muted),
+              ),
+              Expanded(
+                child: Text(
+                  ride.destination,
+                  style: GoogleFonts.poppins(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                    color: _Colors.textPrimary,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.end,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+
+          // Details row
+          Row(
+            children: [
+              const Icon(Icons.access_time_outlined, size: 13, color: _Colors.muted),
+              const SizedBox(width: 4),
+              Text(
+                _fmtTime(ride.departureTime),
+                style: GoogleFonts.poppins(fontSize: 12, color: _Colors.textSecondary),
+              ),
+              const SizedBox(width: 12),
+              const Icon(Icons.event_seat_outlined, size: 13, color: _Colors.muted),
+              const SizedBox(width: 4),
+              Text(
+                '${ride.seatsAvailable} seats',
+                style: GoogleFonts.poppins(fontSize: 12, color: _Colors.textSecondary),
+              ),
+              const SizedBox(width: 12),
+              Text(
+                _fmtPrice(ride.price),
+                style: GoogleFonts.poppins(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                  color: _Colors.textPrimary,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+
+          // Status row
+          Row(
+            children: [
+              _StatusChip(status: ride.status),
+            ],
+          ),
+
+          if (isPending) ...[
+            const SizedBox(height: 6),
+            Text(
+              'Will publish when reconnected',
+              style: GoogleFonts.poppins(
+                fontSize: 11,
+                color: _Colors.orange,
+              ),
+            ),
+          ],
+
+          const SizedBox(height: 12),
+          const Divider(color: _Colors.border, height: 1),
+          const SizedBox(height: 12),
+
+          // Action buttons row
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: canNavigate
+                      ? () => context.push(
+                            '/driver/ride-requests',
+                            extra: {
+                              'rideId': ride.id,
+                              'origin': ride.origin,
+                              'destination': ride.destination,
+                            },
+                          )
+                      : null,
+                  style: OutlinedButton.styleFrom(
+                    side: BorderSide(
+                      color: canNavigate ? _Colors.primary : _Colors.border,
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    padding: const EdgeInsets.symmetric(vertical: 10),
+                  ),
+                  child: Text(
+                    'View Requests',
+                    style: GoogleFonts.poppins(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                      color: canNavigate ? _Colors.primary : _Colors.muted,
+                    ),
+                  ),
+                ),
+              ),
+              if (showActiveRide) ...[
+                const SizedBox(width: 8),
+                Expanded(
+                  child: TextButton(
+                    onPressed: () => context.push(
+                      '/driver/active-ride',
+                      extra: {'rideId': ride.id},
+                    ),
+                    style: TextButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(vertical: 10),
+                    ),
+                    child: Text(
+                      'Active Ride →',
+                      style: GoogleFonts.poppins(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                        color: _Colors.primary,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ],
+      ),
+      ),
+    );
+  }
+}
+
+class _StatusChip extends StatelessWidget {
+  const _StatusChip({required this.status});
+
+  final String status;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color bg;
+    final Color fg;
+    final String label;
+
+    switch (status) {
+      case 'available':
+        bg = const Color(0xFFDCFCE7);
+        fg = _Colors.green;
+        label = 'Available';
+      case 'in_progress':
+        bg = const Color(0xFFDBEAFE);
+        fg = _Colors.blue;
+        label = 'In Progress';
+      case 'completed':
+        bg = const Color(0xFFF3F4F6);
+        fg = _Colors.grey;
+        label = 'Completed';
+      default: // 'pending'
+        bg = const Color(0xFFFED7AA);
+        fg = _Colors.orange;
+        label = 'Pending';
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Text(
+        label,
+        style: GoogleFonts.poppins(
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+          color: fg,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/driver/my_rides/my_rides_screen.dart
+++ b/lib/features/driver/my_rides/my_rides_screen.dart
@@ -5,6 +5,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
 
 import '../../../data/models/ride_model.dart';
+import '../../../shared/widgets/bottom_nav_bar.dart';
 import '../../../shared/widgets/offline_banner.dart';
 import 'my_rides_viewmodel.dart';
 
@@ -20,6 +21,9 @@ abstract final class _Colors {
   static const blue = Color(0xFF2563EB);
   static const orange = Color(0xFFF97316);
   static const grey = Color(0xFF9CA3AF);
+  static const red = Color(0xFFDC2626);
+  static const redLight = Color(0xFFFEF2F2);
+  static const redBorder = Color(0xFFFCA5A5);
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -64,14 +68,12 @@ class _MyRidesScreenState extends State<MyRidesScreen> {
 
     return Scaffold(
       backgroundColor: _Colors.background,
+      bottomNavigationBar: const UniRideBottomNav(currentIndex: 1),
       appBar: AppBar(
         backgroundColor: _Colors.background,
         elevation: 0,
         scrolledUnderElevation: 0,
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back_ios_new, color: _Colors.textPrimary),
-          onPressed: () => context.go('/home'),
-        ),
+        automaticallyImplyLeading: false,
         title: Text(
           'My Rides',
           style: GoogleFonts.poppins(
@@ -175,6 +177,9 @@ class _RideDriverCard extends StatelessWidget {
     final canNavigate = !isPending;
     final showActiveRide =
         ride.status == 'available' || ride.status == 'in_progress';
+    final now = DateTime.now();
+    final isOverdue = (ride.status == 'available' || ride.status == 'active') &&
+        ride.departureTime.isBefore(now);
 
     return GestureDetector(
       onTap: () async {
@@ -192,9 +197,12 @@ class _RideDriverCard extends StatelessWidget {
       child: Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: _Colors.background,
+        color: isOverdue ? _Colors.redLight : _Colors.background,
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: _Colors.border),
+        border: Border.all(
+          color: isOverdue ? _Colors.redBorder : _Colors.border,
+          width: isOverdue ? 1.5 : 1,
+        ),
         boxShadow: const [
           BoxShadow(offset: Offset(0, 2), blurRadius: 8, color: Color(0x0A000000)),
         ],
@@ -278,11 +286,30 @@ class _RideDriverCard extends StatelessWidget {
           // Status row
           Row(
             children: [
-              _StatusChip(status: ride.status),
+              _StatusChip(status: ride.status, isOverdue: isOverdue),
             ],
           ),
 
-          if (isPending) ...[
+          if (isOverdue) ...[
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                const Icon(Icons.warning_amber_rounded,
+                    size: 14, color: _Colors.red),
+                const SizedBox(width: 4),
+                Expanded(
+                  child: Text(
+                    '¡Hora de salida pasada! Inicia el viaje o se cancelará automáticamente.',
+                    style: GoogleFonts.poppins(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w600,
+                      color: _Colors.red,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ] else if (isPending) ...[
             const SizedBox(height: 6),
             Text(
               'Will publish when reconnected',
@@ -363,12 +390,39 @@ class _RideDriverCard extends StatelessWidget {
 }
 
 class _StatusChip extends StatelessWidget {
-  const _StatusChip({required this.status});
+  const _StatusChip({required this.status, this.isOverdue = false});
 
   final String status;
+  final bool isOverdue;
 
   @override
   Widget build(BuildContext context) {
+    if (isOverdue) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+        decoration: BoxDecoration(
+          color: const Color(0xFFFEE2E2),
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.warning_amber_rounded,
+                size: 11, color: _Colors.red),
+            const SizedBox(width: 3),
+            Text(
+              '¡Iniciar ya!',
+              style: GoogleFonts.poppins(
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                color: _Colors.red,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
     final Color bg;
     final Color fg;
     final String label;

--- a/lib/features/driver/my_rides/my_rides_screen.dart
+++ b/lib/features/driver/my_rides/my_rides_screen.dart
@@ -173,13 +173,14 @@ class _RideDriverCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final vm = context.read<MyRidesViewModel>();
     final isPending = ride.status == 'pending';
     final canNavigate = !isPending;
-    final showActiveRide =
-        ride.status == 'available' || ride.status == 'in_progress';
+    final showActiveRide = ride.status == 'in_progress';
     final now = DateTime.now();
     final isOverdue = (ride.status == 'available' || ride.status == 'active') &&
         ride.departureTime.isBefore(now);
+    final pendingCount = vm.pendingCountFor(ride.id);
 
     return GestureDetector(
       onTap: () async {
@@ -287,6 +288,34 @@ class _RideDriverCard extends StatelessWidget {
           Row(
             children: [
               _StatusChip(status: ride.status, isOverdue: isOverdue),
+              if (pendingCount > 0) ...[
+                const SizedBox(width: 8),
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 8, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFFFEF3C7),
+                    borderRadius: BorderRadius.circular(20),
+                    border: Border.all(color: const Color(0xFFFCD34D)),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const Icon(Icons.person_add_alt_1,
+                          size: 11, color: Color(0xFF92400E)),
+                      const SizedBox(width: 3),
+                      Text(
+                        '$pendingCount solicitud${pendingCount > 1 ? 'es' : ''}',
+                        style: GoogleFonts.poppins(
+                          fontSize: 11,
+                          fontWeight: FontWeight.w600,
+                          color: const Color(0xFF92400E),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
             ],
           ),
 

--- a/lib/features/driver/my_rides/my_rides_viewmodel.dart
+++ b/lib/features/driver/my_rides/my_rides_viewmodel.dart
@@ -1,0 +1,79 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../../../core/connectivity/connectivity_service.dart';
+import '../../../core/db/daos/ride_dao.dart';
+import '../../../core/db/database_helper.dart';
+import '../../../data/models/ride_model.dart';
+import '../../../data/repositories/impl/firebase_ride_repository.dart';
+
+class MyRidesViewModel extends ChangeNotifier {
+  MyRidesViewModel() {
+    _repository = FirebaseRideRepository();
+    _dao = RideDao(DatabaseHelper());
+
+    // Check current connectivity immediately (not just on change)
+    ConnectivityService().isOnline().then((online) {
+      isOffline = !online;
+      notifyListeners();
+    });
+
+    _connSub = ConnectivityService().onStatusChanged.listen((online) {
+      final wasOffline = isOffline;
+      isOffline = !online;
+      notifyListeners();
+
+      // Auto-refresh when coming back online
+      if (online && wasOffline && _lastDriverId != null) {
+        loadRides(_lastDriverId!);
+      }
+    });
+  }
+
+  late final FirebaseRideRepository _repository;
+  late final RideDao _dao;
+  StreamSubscription<bool>? _connSub;
+
+  String? _lastDriverId;
+
+  List<RideModel> rides = [];
+  bool isLoading = false;
+  bool isOffline = false;
+  bool isFromCache = false;
+  String? errorMessage;
+
+  Future<void> loadRides(String driverId) async {
+    _lastDriverId = driverId;
+    isLoading = true;
+    errorMessage = null;
+    notifyListeners();
+
+    try {
+      rides = await _repository.getDriverRides(driverId);
+      unawaited(_dao.insertOrReplaceAll(rides));
+      isFromCache = false;
+    } catch (e) {
+      debugPrint('[MyRides] Firestore failed: $e');
+      final now = DateTime.now();
+      final cached = await _dao.fetchAll();
+      rides = cached
+          .where((r) =>
+              r.driverId == driverId &&
+              (r.departureTime.isAfter(now) || r.status == 'in_progress'))
+          .toList()
+        ..sort((a, b) => a.departureTime.compareTo(b.departureTime));
+      // Only show cache banner if we actually have cached data to show
+      isFromCache = rides.isNotEmpty;
+    } finally {
+      isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  @override
+  void dispose() {
+    _connSub?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/features/driver/my_rides/my_rides_viewmodel.dart
+++ b/lib/features/driver/my_rides/my_rides_viewmodel.dart
@@ -32,7 +32,9 @@ class MyRidesViewModel extends ChangeNotifier {
   late final RideDao _dao;
   StreamSubscription<bool>? _connSub;
   StreamSubscription<QuerySnapshot>? _ridesSub;
+  StreamSubscription<QuerySnapshot>? _requestsSub;
   final Set<String> _expiringRides = {};
+  final Map<String, int> _pendingCounts = {};
 
   String? _lastDriverId;
 
@@ -41,6 +43,8 @@ class MyRidesViewModel extends ChangeNotifier {
   bool isOffline = false;
   bool isFromCache = false;
   String? errorMessage;
+
+  int pendingCountFor(String rideId) => _pendingCounts[rideId] ?? 0;
 
   void loadRides(String driverId) {
     _lastDriverId = driverId;
@@ -93,6 +97,7 @@ class MyRidesViewModel extends ChangeNotifier {
         unawaited(_dao.insertOrReplaceAll(rides));
         isFromCache = false;
         isLoading = false;
+        _subscribeToPendingRequests(rides.map((r) => r.id).toList());
         notifyListeners();
       },
       onError: (e) async {
@@ -115,9 +120,38 @@ class MyRidesViewModel extends ChangeNotifier {
     );
   }
 
+  void _subscribeToPendingRequests(List<String> rideIds) {
+    _requestsSub?.cancel();
+    _pendingCounts.clear();
+    if (rideIds.isEmpty) {
+      notifyListeners();
+      return;
+    }
+    // Firestore whereIn limit is 30; drivers won't exceed that in practice
+    final ids = rideIds.take(30).toList();
+    _requestsSub = FirebaseFirestore.instance
+        .collection('rideRequests')
+        .where('rideId', whereIn: ids)
+        .where('status', isEqualTo: 'pending')
+        .snapshots()
+        .listen((snap) {
+          _pendingCounts.clear();
+          for (final doc in snap.docs) {
+            final rideId = doc.data()['rideId'] as String?;
+            if (rideId != null) {
+              _pendingCounts[rideId] = (_pendingCounts[rideId] ?? 0) + 1;
+            }
+          }
+          notifyListeners();
+        }, onError: (e) {
+          debugPrint('[MyRides] pending requests stream error: $e');
+        });
+  }
+
   @override
   void dispose() {
     _ridesSub?.cancel();
+    _requestsSub?.cancel();
     _connSub?.cancel();
     super.dispose();
   }

--- a/lib/features/driver/my_rides/my_rides_viewmodel.dart
+++ b/lib/features/driver/my_rides/my_rides_viewmodel.dart
@@ -1,19 +1,17 @@
 import 'dart:async';
 
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
 
 import '../../../core/connectivity/connectivity_service.dart';
 import '../../../core/db/daos/ride_dao.dart';
 import '../../../core/db/database_helper.dart';
 import '../../../data/models/ride_model.dart';
-import '../../../data/repositories/impl/firebase_ride_repository.dart';
 
 class MyRidesViewModel extends ChangeNotifier {
   MyRidesViewModel() {
-    _repository = FirebaseRideRepository();
     _dao = RideDao(DatabaseHelper());
 
-    // Check current connectivity immediately (not just on change)
     ConnectivityService().isOnline().then((online) {
       isOffline = !online;
       notifyListeners();
@@ -24,16 +22,15 @@ class MyRidesViewModel extends ChangeNotifier {
       isOffline = !online;
       notifyListeners();
 
-      // Auto-refresh when coming back online
       if (online && wasOffline && _lastDriverId != null) {
-        loadRides(_lastDriverId!);
+        _subscribeToRides(_lastDriverId!);
       }
     });
   }
 
-  late final FirebaseRideRepository _repository;
   late final RideDao _dao;
   StreamSubscription<bool>? _connSub;
+  StreamSubscription<QuerySnapshot>? _ridesSub;
 
   String? _lastDriverId;
 
@@ -43,36 +40,57 @@ class MyRidesViewModel extends ChangeNotifier {
   bool isFromCache = false;
   String? errorMessage;
 
-  Future<void> loadRides(String driverId) async {
+  void loadRides(String driverId) {
     _lastDriverId = driverId;
+    _subscribeToRides(driverId);
+  }
+
+  void _subscribeToRides(String driverId) {
+    _ridesSub?.cancel();
+
     isLoading = true;
     errorMessage = null;
     notifyListeners();
 
-    try {
-      rides = await _repository.getDriverRides(driverId);
-      unawaited(_dao.insertOrReplaceAll(rides));
-      isFromCache = false;
-    } catch (e) {
-      debugPrint('[MyRides] Firestore failed: $e');
-      final now = DateTime.now();
-      final cached = await _dao.fetchAll();
-      rides = cached
-          .where((r) =>
-              r.driverId == driverId &&
-              (r.departureTime.isAfter(now) || r.status == 'in_progress'))
-          .toList()
-        ..sort((a, b) => a.departureTime.compareTo(b.departureTime));
-      // Only show cache banner if we actually have cached data to show
-      isFromCache = rides.isNotEmpty;
-    } finally {
-      isLoading = false;
-      notifyListeners();
-    }
+    final now = DateTime.now();
+
+    _ridesSub = FirebaseFirestore.instance
+        .collection('rides')
+        .where('driverId', isEqualTo: driverId)
+        .snapshots()
+        .listen(
+      (snap) {
+        rides = snap.docs
+            .map((d) => RideModel.fromMap(d.data(), d.id))
+            .where((r) =>
+                r.departureTime.isAfter(now) || r.status == 'in_progress')
+            .toList()
+          ..sort((a, b) => a.departureTime.compareTo(b.departureTime));
+
+        unawaited(_dao.insertOrReplaceAll(rides));
+        isFromCache = false;
+        isLoading = false;
+        notifyListeners();
+      },
+      onError: (e) async {
+        debugPrint('[MyRides] Firestore stream failed: $e');
+        final cached = await _dao.fetchAll();
+        rides = cached
+            .where((r) =>
+                r.driverId == driverId &&
+                (r.departureTime.isAfter(now) || r.status == 'in_progress'))
+            .toList()
+          ..sort((a, b) => a.departureTime.compareTo(b.departureTime));
+        isFromCache = rides.isNotEmpty;
+        isLoading = false;
+        notifyListeners();
+      },
+    );
   }
 
   @override
   void dispose() {
+    _ridesSub?.cancel();
     _connSub?.cancel();
     super.dispose();
   }

--- a/lib/features/driver/my_rides/my_rides_viewmodel.dart
+++ b/lib/features/driver/my_rides/my_rides_viewmodel.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
 import 'package:flutter/foundation.dart';
 
 import '../../../core/connectivity/connectivity_service.dart';
@@ -31,6 +32,7 @@ class MyRidesViewModel extends ChangeNotifier {
   late final RideDao _dao;
   StreamSubscription<bool>? _connSub;
   StreamSubscription<QuerySnapshot>? _ridesSub;
+  final Set<String> _expiringRides = {};
 
   String? _lastDriverId;
 
@@ -52,7 +54,7 @@ class MyRidesViewModel extends ChangeNotifier {
     errorMessage = null;
     notifyListeners();
 
-    final now = DateTime.now();
+    final grace = const Duration(minutes: 15);
 
     _ridesSub = FirebaseFirestore.instance
         .collection('rides')
@@ -60,10 +62,31 @@ class MyRidesViewModel extends ChangeNotifier {
         .snapshots()
         .listen(
       (snap) {
-        rides = snap.docs
-            .map((d) => RideModel.fromMap(d.data(), d.id))
+        final now = DateTime.now();
+        final allRides = snap.docs.map((d) => RideModel.fromMap(d.data(), d.id)).toList();
+
+        // Auto-expire available/active rides past the 15-min grace window
+        for (final r in allRides) {
+          if ((r.status == 'available' || r.status == 'active') &&
+              r.departureTime.add(grace).isBefore(now) &&
+              !_expiringRides.contains(r.id)) {
+            _expiringRides.add(r.id);
+            FirebaseFunctions.instance
+                .httpsCallable('autoExpireRide')
+                .call({'rideId': r.id})
+                .then((_) => debugPrint('[MyRides] auto-expired ${r.id}'))
+                .catchError((e) {
+                  debugPrint('[MyRides] autoExpireRide failed for ${r.id}: $e');
+                  _expiringRides.remove(r.id);
+                });
+          }
+        }
+
+        rides = allRides
             .where((r) =>
-                r.departureTime.isAfter(now) || r.status == 'in_progress')
+                r.status == 'in_progress' ||
+                ((r.status == 'available' || r.status == 'active') &&
+                    r.departureTime.add(grace).isAfter(now)))
             .toList()
           ..sort((a, b) => a.departureTime.compareTo(b.departureTime));
 
@@ -74,11 +97,15 @@ class MyRidesViewModel extends ChangeNotifier {
       },
       onError: (e) async {
         debugPrint('[MyRides] Firestore stream failed: $e');
+        final now = DateTime.now();
+        final grace = const Duration(minutes: 15);
         final cached = await _dao.fetchAll();
         rides = cached
             .where((r) =>
                 r.driverId == driverId &&
-                (r.departureTime.isAfter(now) || r.status == 'in_progress'))
+                (r.status == 'in_progress' ||
+                    ((r.status == 'available' || r.status == 'active') &&
+                        r.departureTime.add(grace).isAfter(now))))
             .toList()
           ..sort((a, b) => a.departureTime.compareTo(b.departureTime));
         isFromCache = rides.isNotEmpty;

--- a/lib/features/driver/ride_requests/accept_reject_sheet.dart
+++ b/lib/features/driver/ride_requests/accept_reject_sheet.dart
@@ -1,0 +1,190 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:intl/intl.dart';
+
+import '../../../data/models/ride_request_model.dart';
+import 'ride_requests_viewmodel.dart';
+
+class AcceptRejectSheet extends StatelessWidget {
+  const AcceptRejectSheet({
+    super.key,
+    required this.request,
+    required this.isAccepting,
+    required this.vm,
+  });
+
+  final RideRequestModel request;
+  final bool isAccepting;
+  final RideRequestsViewModel vm;
+
+  String _formatTime(DateTime dt) => DateFormat('MMM d, h:mm a').format(dt);
+
+  @override
+  Widget build(BuildContext context) {
+    final titleText = isAccepting ? 'Accept Request' : 'Reject Request';
+    final confirmColor = isAccepting ? const Color(0xFF1F5DFF) : Colors.red;
+    final confirmText = isAccepting ? 'Confirm Accept' : 'Confirm Reject';
+    final bodyText = isAccepting
+        ? 'Accepting will reserve 1 seat for this passenger.'
+        : 'This passenger will be notified that their request was not accepted.';
+
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        24,
+        16,
+        24,
+        MediaQuery.of(context).viewInsets.bottom + 24,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Center(
+            child: Container(
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: Colors.grey[300],
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            titleText,
+            style: GoogleFonts.poppins(
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Card(
+            elevation: 0,
+            color: const Color(0xFFF8FAFC),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Text(
+                        request.passengerName,
+                        style: GoogleFonts.poppins(
+                          fontWeight: FontWeight.w600,
+                          fontSize: 15,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      const Icon(Icons.star, color: Colors.amber, size: 16),
+                      Text(
+                        request.passengerRating.toStringAsFixed(1),
+                        style: GoogleFonts.poppins(fontSize: 13),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    'Requested ${_formatTime(request.requestTime)}',
+                    style: GoogleFonts.poppins(
+                      fontSize: 12,
+                      color: const Color(0xFF555555),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            bodyText,
+            style: GoogleFonts.poppins(
+              fontSize: 13,
+              color: const Color(0xFF555555),
+            ),
+          ),
+          const SizedBox(height: 24),
+          if (vm.isOffline) ...[
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+              decoration: BoxDecoration(
+                color: Colors.red[50],
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: Colors.red.shade200),
+              ),
+              child: Text(
+                'No connection — cannot process now',
+                style: GoogleFonts.poppins(
+                  fontSize: 13,
+                  color: Colors.red[700],
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const SizedBox(height: 12),
+          ],
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: () => Navigator.pop(context),
+                  style: OutlinedButton.styleFrom(
+                    minimumSize: const Size(0, 48),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: Text(
+                    'Cancel',
+                    style: GoogleFonts.poppins(),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: (vm.isOffline || vm.isLoading)
+                      ? null
+                      : () async {
+                          if (isAccepting) {
+                            await vm.acceptRequest(request.id, context);
+                          } else {
+                            await vm.rejectRequest(request.id, context);
+                          }
+                          if (context.mounted) Navigator.pop(context);
+                        },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: confirmColor,
+                    foregroundColor: Colors.white,
+                    minimumSize: const Size(0, 48),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: vm.isLoading
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: Colors.white,
+                          ),
+                        )
+                      : Text(
+                          confirmText,
+                          style: GoogleFonts.poppins(
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/driver/ride_requests/ride_requests_screen.dart
+++ b/lib/features/driver/ride_requests/ride_requests_screen.dart
@@ -1,0 +1,221 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:provider/provider.dart';
+
+import '../../../data/models/ride_request_model.dart';
+import '../../../shared/widgets/offline_banner.dart';
+import 'accept_reject_sheet.dart';
+import 'ride_requests_viewmodel.dart';
+
+class RideRequestsScreen extends StatefulWidget {
+  const RideRequestsScreen({super.key});
+
+  @override
+  State<RideRequestsScreen> createState() => _RideRequestsScreenState();
+}
+
+class _RideRequestsScreenState extends State<RideRequestsScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<RideRequestsViewModel>().loadRequests();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<RideRequestsViewModel>();
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '${vm.origin} → ${vm.destination}',
+              style: GoogleFonts.poppins(
+                fontSize: 14,
+                fontWeight: FontWeight.w600,
+                color: const Color(0xFF111111),
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+            Text(
+              'Requests',
+              style: GoogleFonts.poppins(
+                fontSize: 12,
+                color: const Color(0xFF555555),
+              ),
+            ),
+          ],
+        ),
+        iconTheme: const IconThemeData(color: Color(0xFF111111)),
+      ),
+      body: Column(
+        children: [
+          OfflineBanner(
+            isOffline: vm.isOffline,
+            isFromCache: false,
+          ),
+          if (vm.isOffline)
+            Container(
+              width: double.infinity,
+              color: Colors.amber[50],
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Text(
+                'Actions unavailable offline',
+                style: GoogleFonts.poppins(
+                  fontSize: 12,
+                  color: Colors.amber[800],
+                ),
+              ),
+            ),
+          Expanded(
+            child: vm.isLoading && vm.requests.isEmpty
+                ? const Center(child: CircularProgressIndicator())
+                : vm.requests.isEmpty
+                    ? Center(
+                        child: Text(
+                          'No pending requests',
+                          style: GoogleFonts.poppins(
+                            fontSize: 14,
+                            color: const Color(0xFF555555),
+                          ),
+                        ),
+                      )
+                    : ListView.builder(
+                        padding: const EdgeInsets.all(16),
+                        itemCount: vm.requests.length,
+                        itemBuilder: (context, index) {
+                          return _RequestCard(
+                            request: vm.requests[index],
+                            vm: vm,
+                          );
+                        },
+                      ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RequestCard extends StatelessWidget {
+  const _RequestCard({required this.request, required this.vm});
+
+  final RideRequestModel request;
+  final RideRequestsViewModel vm;
+
+  void _showSheet(BuildContext context, bool isAccepting) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (_) => ChangeNotifierProvider.value(
+        value: vm,
+        child: Consumer<RideRequestsViewModel>(
+          builder: (ctx, viewModel, _) => AcceptRejectSheet(
+            request: request,
+            isAccepting: isAccepting,
+            vm: viewModel,
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final initial =
+        request.passengerName.isNotEmpty ? request.passengerName[0] : '?';
+    final rating = request.passengerRating;
+
+    return Card(
+      elevation: 0,
+      color: const Color(0xFFF8FAFC),
+      margin: const EdgeInsets.only(bottom: 12),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: Colors.grey.shade200),
+      ),
+      child: ListTile(
+        contentPadding:
+            const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        leading: CircleAvatar(
+          backgroundColor: const Color(0xFF1F5DFF),
+          child: Text(
+            initial.toUpperCase(),
+            style: GoogleFonts.poppins(
+              color: Colors.white,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        title: Text(
+          request.passengerName,
+          style: GoogleFonts.poppins(
+            fontWeight: FontWeight.w600,
+            fontSize: 14,
+          ),
+        ),
+        subtitle: Row(
+          children: List.generate(5, (i) {
+            return Icon(
+              i < rating.round() ? Icons.star : Icons.star_border,
+              size: 14,
+              color: Colors.amber,
+            );
+          }),
+        ),
+        trailing: vm.isOffline
+            ? Text(
+                'Offline',
+                style: GoogleFonts.poppins(
+                  fontSize: 11,
+                  color: Colors.grey,
+                ),
+              )
+            : Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextButton(
+                    onPressed: () => _showSheet(context, false),
+                    style: TextButton.styleFrom(
+                      foregroundColor: Colors.red,
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                    ),
+                    child: Text(
+                      'Reject',
+                      style: GoogleFonts.poppins(fontSize: 13),
+                    ),
+                  ),
+                  const SizedBox(width: 4),
+                  ElevatedButton(
+                    onPressed: () => _showSheet(context, true),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: const Color(0xFF1F5DFF),
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(horizontal: 12),
+                      minimumSize: const Size(0, 36),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                    child: Text(
+                      'Accept',
+                      style: GoogleFonts.poppins(fontSize: 13),
+                    ),
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+}

--- a/lib/features/driver/ride_requests/ride_requests_viewmodel.dart
+++ b/lib/features/driver/ride_requests/ride_requests_viewmodel.dart
@@ -1,0 +1,158 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+import 'package:flutter/material.dart';
+
+import '../../../core/connectivity/connectivity_service.dart';
+import '../../../data/models/ride_request_model.dart';
+
+class RideRequestsViewModel extends ChangeNotifier {
+  RideRequestsViewModel({
+    required this.rideId,
+    required this.origin,
+    required this.destination,
+  }) {
+    ConnectivityService().isOnline().then((online) {
+      isOffline = !online;
+      notifyListeners();
+    });
+
+    _connSub = ConnectivityService().onStatusChanged.listen((online) {
+      final wasOffline = isOffline;
+      isOffline = !online;
+      notifyListeners();
+      if (online && wasOffline) loadRequests();
+    });
+  }
+
+  final String rideId;
+  final String origin;
+  final String destination;
+
+  List<RideRequestModel> requests = [];
+  bool isLoading = false;
+  bool isOffline = false;
+
+  StreamSubscription<bool>? _connSub;
+
+  Future<void> loadRequests() async {
+    isLoading = true;
+    notifyListeners();
+
+    try {
+      final snapshot = await FirebaseFirestore.instance
+          .collection('rideRequests')
+          .where('rideId', isEqualTo: rideId)
+          .where('status', isEqualTo: 'pending')
+          .get();
+
+      final rawRequests = snapshot.docs
+          .map((doc) => RideRequestModel.fromFirestore(doc))
+          .toList();
+
+      // For any request missing a name, fetch it from the users collection
+      final enriched = await Future.wait(rawRequests.map((req) async {
+        if (req.passengerName != 'Unknown') return req;
+        try {
+          final userSnap = await FirebaseFirestore.instance
+              .collection('users')
+              .doc(req.passengerId)
+              .get();
+          final name = (userSnap.data()?['name'] as String?) ?? 'Unknown';
+          final rating =
+              (userSnap.data()?['reputationScore'] as num?)?.toDouble() ??
+                  req.passengerRating;
+          return RideRequestModel(
+            id: req.id,
+            rideId: req.rideId,
+            passengerId: req.passengerId,
+            passengerName: name,
+            passengerRating: rating,
+            status: req.status,
+            requestTime: req.requestTime,
+          );
+        } catch (_) {
+          return req;
+        }
+      }));
+
+      requests = enriched;
+    } catch (e) {
+      debugPrint('[RideRequests] Firestore failed: $e');
+    } finally {
+      isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> acceptRequest(String requestId, BuildContext context) async {
+    if (isOffline) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Cannot accept offline — requires live data'),
+          ),
+        );
+      }
+      return;
+    }
+
+    isLoading = true;
+    notifyListeners();
+
+    try {
+      await FirebaseFunctions.instance
+          .httpsCallable('acceptRide')
+          .call({'requestId': requestId, 'rideId': rideId});
+    } on FirebaseFunctionsException catch (e) {
+      debugPrint('[RideRequests] acceptRide CF failed: $e');
+      final msg = e.message ?? 'Could not accept request';
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(msg), backgroundColor: Colors.red),
+        );
+      }
+    } catch (e) {
+      debugPrint('[RideRequests] acceptRide unexpected: $e');
+    } finally {
+      isLoading = false;
+    }
+
+    await loadRequests();
+  }
+
+  Future<void> rejectRequest(String requestId, BuildContext context) async {
+    if (isOffline) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Cannot reject offline — requires live data'),
+          ),
+        );
+      }
+      return;
+    }
+
+    isLoading = true;
+    notifyListeners();
+
+    try {
+      await FirebaseFunctions.instance
+          .httpsCallable('rejectRide')
+          .call({'requestId': requestId, 'rideId': rideId});
+    } catch (e) {
+      debugPrint('[RideRequests] rejectRide CF failed: $e');
+    } finally {
+      isLoading = false;
+    }
+
+    await loadRequests();
+  }
+
+  @override
+  void dispose() {
+    _connSub?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -138,21 +138,46 @@ class _HomeScreenState extends State<HomeScreen> {
 
     return Scaffold(
       backgroundColor: _HomeColors.background,
-      floatingActionButton: FloatingActionButton(
-        backgroundColor: _HomeColors.primary,
-        tooltip: 'Asistente UniRide',
-        onPressed: () {
-          showModalBottomSheet(
-            context: context,
-            isScrollControlled: true,
-            backgroundColor: Colors.transparent,
-            builder: (_) => const ChatbotSheet(),
-          );
-        },
-        child: const Icon(
-          Icons.smart_toy_outlined,
-          color: _HomeColors.background,
-        ),
+      floatingActionButton: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Consumer<AuthViewModel>(
+            builder: (_, auth, __) {
+              final role = auth.currentUser?.role ?? 'passenger';
+              final isDriver = role == 'driver' ||
+                  (role == 'both' && auth.activeMode == 'driver');
+              if (!isDriver) return const SizedBox.shrink();
+              return Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: FloatingActionButton(
+                  heroTag: 'create_ride_fab',
+                  onPressed: () => context.push('/driver/create-ride'),
+                  backgroundColor: const Color(0xFF1A56DB),
+                  mini: true,
+                  tooltip: 'Create a ride',
+                  child: const Icon(Icons.add, color: Colors.white),
+                ),
+              );
+            },
+          ),
+          FloatingActionButton(
+            heroTag: 'chatbot_fab',
+            backgroundColor: _HomeColors.primary,
+            tooltip: 'Asistente UniRide',
+            onPressed: () {
+              showModalBottomSheet(
+                context: context,
+                isScrollControlled: true,
+                backgroundColor: Colors.transparent,
+                builder: (_) => const ChatbotSheet(),
+              );
+            },
+            child: const Icon(
+              Icons.smart_toy_outlined,
+              color: _HomeColors.background,
+            ),
+          ),
+        ],
       ),
       bottomNavigationBar: const UniRideBottomNav(currentIndex: 0),
       body: SafeArea(
@@ -305,6 +330,52 @@ class _HomeHeader extends StatelessWidget {
                     fontWeight: FontWeight.w700,
                     color: _HomeColors.textPrimary,
                   ),
+                ),
+                const SizedBox(height: 4),
+                Consumer<AuthViewModel>(
+                  builder: (_, auth, __) {
+                    final role = auth.currentUser?.role ?? 'passenger';
+                    final isDriver = role == 'driver' ||
+                        (role == 'both' && auth.activeMode == 'driver');
+                    return Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 8, vertical: 2),
+                      decoration: BoxDecoration(
+                        color: isDriver
+                            ? const Color(0xFF1A56DB).withOpacity(0.1)
+                            : Colors.grey.withOpacity(0.1),
+                        borderRadius: BorderRadius.circular(12),
+                        border: Border.all(
+                          color: isDriver
+                              ? const Color(0xFF1A56DB).withOpacity(0.3)
+                              : Colors.grey.withOpacity(0.3),
+                        ),
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            isDriver ? Icons.drive_eta : Icons.person,
+                            size: 12,
+                            color: isDriver
+                                ? const Color(0xFF1A56DB)
+                                : Colors.grey[600],
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            isDriver ? 'Driver mode' : 'Passenger mode',
+                            style: TextStyle(
+                              fontSize: 11,
+                              fontWeight: FontWeight.w500,
+                              color: isDriver
+                                  ? const Color(0xFF1A56DB)
+                                  : Colors.grey[600],
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
                 ),
                 // ⚠️ AQUÍ ESTÁ LA CORRECCIÓN DEL NUEVO OVERFLOW
                 Row(

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -14,10 +14,12 @@ import '../../core/db/daos/ride_dao.dart';
 import '../../core/db/database_helper.dart';
 import '../../core/location_utils.dart';
 import '../../core/utils/geocoding_service.dart';
+import '../../data/models/notification_model.dart';
 import '../../data/models/ride_model.dart';
 import '../../data/models/weather_model.dart';
 import '../../features/auth/auth_viewmodel.dart';
 import '../../features/home/weather_viewmodel.dart';
+import '../../features/notifications/notifications_viewmodel.dart';
 import '../../features/rides/ride_viewmodel.dart';
 import '../chatbot/presentation/chatbot_sheet.dart';
 
@@ -404,16 +406,247 @@ class _HomeHeader extends StatelessWidget {
               ],
             ),
           ),
-          const _WeatherChip(), // Mantén este con la corrección anterior
-          const SizedBox(width: 8),
-          IconButton(
-            icon: const Icon(
-              Icons.notifications_outlined,
-              color: _HomeColors.textPrimary,
-            ),
-            onPressed: () {},
+          const _WeatherChip(),
+          const SizedBox(width: 4),
+          Consumer<NotificationsViewModel>(
+            builder: (ctx, vm, _) {
+              final count = vm.unreadCount;
+              return Stack(
+                clipBehavior: Clip.none,
+                children: [
+                  IconButton(
+                    icon: const Icon(
+                      Icons.notifications_outlined,
+                      color: _HomeColors.textPrimary,
+                    ),
+                    onPressed: () => _showNotificationsDialog(ctx, vm),
+                  ),
+                  if (count > 0)
+                    Positioned(
+                      top: 6,
+                      right: 6,
+                      child: IgnorePointer(
+                        child: Container(
+                          width: 16,
+                          height: 16,
+                          decoration: const BoxDecoration(
+                            color: Color(0xFFEF4444),
+                            shape: BoxShape.circle,
+                          ),
+                          child: Center(
+                            child: Text(
+                              count > 9 ? '9+' : '$count',
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 9,
+                                fontWeight: FontWeight.w700,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                ],
+              );
+            },
           ),
         ],
+      ),
+    );
+  }
+}
+
+void _showNotificationsDialog(
+    BuildContext context, NotificationsViewModel vm) {
+  vm.markAllAsRead();
+  showDialog<void>(
+    context: context,
+    builder: (_) => _NotificationsDialog(vm: vm),
+  );
+}
+
+class _NotificationsDialog extends StatelessWidget {
+  const _NotificationsDialog({required this.vm});
+
+  final NotificationsViewModel vm;
+
+  String _timeAgo(DateTime dt) {
+    final diff = DateTime.now().difference(dt);
+    if (diff.inMinutes < 1) return 'Just now';
+    if (diff.inHours < 1) return '${diff.inMinutes}m ago';
+    if (diff.inDays < 1) return '${diff.inHours}h ago';
+    return '${diff.inDays}d ago';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      insetPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 80),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 20, 8, 0),
+            child: Row(
+              children: [
+                Text(
+                  'Notifications',
+                  style: GoogleFonts.poppins(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w700,
+                    color: _HomeColors.textPrimary,
+                  ),
+                ),
+                const Spacer(),
+                IconButton(
+                  icon: const Icon(Icons.close, size: 20),
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              ],
+            ),
+          ),
+          const Divider(height: 1),
+          ChangeNotifierProvider<NotificationsViewModel>.value(
+            value: vm,
+            child: Consumer<NotificationsViewModel>(
+              builder: (ctx, notifVm, _) {
+                final items = notifVm.notifications;
+                if (items.isEmpty) {
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 40),
+                    child: Column(
+                      children: [
+                        const Icon(Icons.notifications_none,
+                            size: 48, color: Color(0xFF94A3B8)),
+                        const SizedBox(height: 12),
+                        Text(
+                          'No notifications yet',
+                          style: GoogleFonts.poppins(
+                            fontSize: 13,
+                            color: _HomeColors.muted,
+                          ),
+                        ),
+                      ],
+                    ),
+                  );
+                }
+                return ConstrainedBox(
+                  constraints: BoxConstraints(
+                    maxHeight: MediaQuery.of(ctx).size.height * 0.5,
+                  ),
+                  child: ListView.separated(
+                    shrinkWrap: true,
+                    padding: const EdgeInsets.symmetric(vertical: 8),
+                    itemCount: items.length,
+                    separatorBuilder: (_, __) =>
+                        const Divider(height: 1, indent: 16, endIndent: 16),
+                    itemBuilder: (_, i) =>
+                        _NotifTile(item: items[i], timeAgo: _timeAgo),
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NotifTile extends StatelessWidget {
+  const _NotifTile({required this.item, required this.timeAgo});
+
+  final NotificationModel item;
+  final String Function(DateTime) timeAgo;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color iconBg;
+    final Color iconColor;
+    final IconData iconData;
+    switch (item.type) {
+      case 'accepted':
+        iconBg = const Color(0xFFDCFCE7);
+        iconColor = const Color(0xFF16A34A);
+        iconData = Icons.check_circle;
+      case 'rejected':
+        iconBg = const Color(0xFFFFEDED);
+        iconColor = const Color(0xFFDC2626);
+        iconData = Icons.cancel;
+      default: // new_request
+        iconBg = const Color(0xFFEFF6FF);
+        iconColor = _HomeColors.primary;
+        iconData = Icons.person_add_alt_1;
+    }
+
+    return InkWell(
+      onTap: () {
+        Navigator.of(context).pop();
+        if (item.rideId.isEmpty) return;
+        if (item.type == 'new_request') {
+          context.push('/driver/ride-requests', extra: {
+            'rideId': item.rideId,
+            'origin': item.origin,
+            'destination': item.destination,
+          });
+        } else {
+          context.push('/rides/${item.rideId}');
+        }
+      },
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              width: 36,
+              height: 36,
+              decoration: BoxDecoration(
+                color: iconBg,
+                shape: BoxShape.circle,
+              ),
+              child: Icon(iconData, size: 18, color: iconColor),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    item.message,
+                    style: GoogleFonts.poppins(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w500,
+                      color: _HomeColors.textPrimary,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Row(
+                    children: [
+                      Text(
+                        timeAgo(item.createdAt),
+                        style: GoogleFonts.poppins(
+                          fontSize: 11,
+                          color: _HomeColors.muted,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        'Ver viaje →',
+                        style: GoogleFonts.poppins(
+                          fontSize: 11,
+                          fontWeight: FontWeight.w600,
+                          color: _HomeColors.primary,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -370,6 +370,13 @@ class _HomeScreenState extends State<HomeScreen> {
 
 // ── Private widgets ──────────────────────────────────────────────────────────
 
+String _greeting() {
+  final hour = DateTime.now().hour;
+  if (hour < 12) return 'Good morning,';
+  if (hour < 18) return 'Good afternoon,';
+  return 'Good evening,';
+}
+
 class _HomeHeader extends StatelessWidget {
   const _HomeHeader({required this.firstName});
 
@@ -386,7 +393,7 @@ class _HomeHeader extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  'Good morning,',
+                  _greeting(),
                   style: GoogleFonts.poppins(
                     fontSize: 16,
                     fontWeight: FontWeight.w400,

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:go_router/go_router.dart';
@@ -94,6 +95,33 @@ class _HomeScreenState extends State<HomeScreen> {
   bool _weatherBannerDismissed = false;
   final GlobalKey<_SearchCardState> _searchCardKey = GlobalKey();
   final ScrollController _scrollController = ScrollController();
+  RideModel? _activeRide;
+  StreamSubscription<QuerySnapshot>? _activeRideSub;
+
+  void _subscribeToActiveRide() {
+    final userId = context.read<AuthViewModel>().currentUser?.id;
+    if (userId == null) return;
+    final role = context.read<AuthViewModel>().currentUser?.role ?? 'passenger';
+    if (role != 'driver' && role != 'both') return;
+
+    _activeRideSub = FirebaseFirestore.instance
+        .collection('rides')
+        .where('driverId', isEqualTo: userId)
+        .where('status', isEqualTo: 'in_progress')
+        .limit(1)
+        .snapshots()
+        .listen(
+      (snap) {
+        if (!mounted) return;
+        setState(() {
+          _activeRide = snap.docs.isNotEmpty
+              ? RideModel.fromMap(snap.docs.first.data(), snap.docs.first.id)
+              : null;
+        });
+      },
+      onError: (e) => debugPrint('[Home] active ride stream error: $e'),
+    );
+  }
 
   void _onRecurringRideTap(String origin, String destination) {
     _searchCardKey.currentState?.fillRoute(origin, destination);
@@ -106,6 +134,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
   @override
   void dispose() {
+    _activeRideSub?.cancel();
     _scrollController.dispose();
     super.dispose();
   }
@@ -121,6 +150,7 @@ class _HomeScreenState extends State<HomeScreen> {
       context.read<WeatherViewModel>().loadWeather();
       context.read<WeatherViewModel>().startAutoRefresh();
       context.read<AuthViewModel>().loadRecurringRoutes();
+      _subscribeToActiveRide();
     });
   }
 
@@ -195,6 +225,44 @@ class _HomeScreenState extends State<HomeScreen> {
                   isFromCache: vm.isFromCache,
                 ),
               ),
+
+              // Active ride banner (driver only)
+              if (_activeRide != null)
+                InkWell(
+                  onTap: () => context.push(
+                    '/driver/active-ride',
+                    extra: {'rideId': _activeRide!.id},
+                  ),
+                  child: Container(
+                    width: double.infinity,
+                    color: const Color(0xFF1A56DB),
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 16, vertical: 10),
+                    child: Row(
+                      children: [
+                        const Icon(Icons.drive_eta,
+                            color: Colors.white, size: 18),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            'Active ride: ${_activeRide!.origin} → '
+                            '${_activeRide!.destination}',
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.w500,
+                              fontSize: 13,
+                            ),
+                          ),
+                        ),
+                        const Text(
+                          'Manage →',
+                          style: TextStyle(
+                              color: Colors.white70, fontSize: 12),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
 
               // Header
               _HomeHeader(firstName: firstName),

--- a/lib/features/notifications/notifications_viewmodel.dart
+++ b/lib/features/notifications/notifications_viewmodel.dart
@@ -1,0 +1,81 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../data/models/notification_model.dart';
+
+class NotificationsViewModel extends ChangeNotifier {
+  NotificationsViewModel() {
+    _authSub = FirebaseAuth.instance.authStateChanges().listen((user) {
+      if (user != null) {
+        _subscribe(user.uid);
+      } else {
+        _notifSub?.cancel();
+        notifications = [];
+        notifyListeners();
+      }
+    });
+  }
+
+  StreamSubscription<User?>? _authSub;
+  StreamSubscription<QuerySnapshot>? _notifSub;
+
+  List<NotificationModel> notifications = [];
+
+  int get unreadCount => notifications.where((n) => !n.read).length;
+
+  void _subscribe(String uid) {
+    _notifSub?.cancel();
+    _notifSub = FirebaseFirestore.instance
+        .collection('notifications')
+        .where('userId', isEqualTo: uid)
+        .snapshots()
+        .listen(
+      (snap) {
+        notifications = snap.docs
+            .map((d) => NotificationModel.fromFirestore(d))
+            .toList()
+          ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+        notifyListeners();
+      },
+      onError: (e) => debugPrint('[Notifications] stream error: $e'),
+    );
+  }
+
+  Future<void> markAsRead(String notificationId) async {
+    try {
+      await FirebaseFirestore.instance
+          .collection('notifications')
+          .doc(notificationId)
+          .update({'read': true});
+    } catch (e) {
+      debugPrint('[Notifications] markAsRead failed: $e');
+    }
+  }
+
+  Future<void> markAllAsRead() async {
+    final unread = notifications.where((n) => !n.read).toList();
+    if (unread.isEmpty) return;
+    final batch = FirebaseFirestore.instance.batch();
+    for (final n in unread) {
+      batch.update(
+        FirebaseFirestore.instance.collection('notifications').doc(n.id),
+        {'read': true},
+      );
+    }
+    try {
+      await batch.commit();
+    } catch (e) {
+      debugPrint('[Notifications] markAllAsRead failed: $e');
+    }
+  }
+
+  @override
+  void dispose() {
+    _authSub?.cancel();
+    _notifSub?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/features/profile/profile_screen.dart
+++ b/lib/features/profile/profile_screen.dart
@@ -1,6 +1,9 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:provider/provider.dart';
+import 'package:uniride/features/auth/auth_viewmodel.dart';
 import 'package:uniride/shared/widgets/bottom_nav_bar.dart';
 
 class ProfileScreen extends StatelessWidget {
@@ -157,6 +160,208 @@ class ProfileScreen extends StatelessWidget {
           ),
 
           const SizedBox(height: 20),
+
+          // Role management section
+          Consumer<AuthViewModel>(
+            builder: (context, auth, __) {
+              final role = auth.currentUser?.role ?? 'passenger';
+              final userId = auth.currentUser?.id ?? '';
+
+              Future<void> upgradeRole() async {
+                await FirebaseFirestore.instance
+                    .collection('users')
+                    .doc(userId)
+                    .update({'role': 'both'});
+                await auth.refreshCurrentUser();
+              }
+
+              Future<void> showUpgradeDialog(String description) async {
+                final confirmed = await showDialog<bool>(
+                  context: context,
+                  builder: (ctx) => AlertDialog(
+                    shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(16)),
+                    title: Text(
+                      'Switch to Both mode',
+                      style: GoogleFonts.poppins(
+                        fontWeight: FontWeight.w600,
+                        fontSize: 16,
+                        color: const Color(0xFF0F172A),
+                      ),
+                    ),
+                    content: Text(
+                      description,
+                      style: GoogleFonts.poppins(
+                        fontSize: 13,
+                        color: const Color(0xFF475569),
+                      ),
+                    ),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.pop(ctx, false),
+                        child: Text('Cancel',
+                            style: GoogleFonts.poppins(
+                                color: const Color(0xFF64748B))),
+                      ),
+                      ElevatedButton(
+                        onPressed: () => Navigator.pop(ctx, true),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: const Color(0xFF1F5DFF),
+                          foregroundColor: Colors.white,
+                          elevation: 0,
+                          shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(10)),
+                        ),
+                        child: Text('Confirm',
+                            style: GoogleFonts.poppins(
+                                fontWeight: FontWeight.w600)),
+                      ),
+                    ],
+                  ),
+                );
+                if (confirmed == true) await upgradeRole();
+              }
+
+              Widget _chip(
+                String label,
+                IconData icon, {
+                required bool isActive,
+                VoidCallback? onTap,
+              }) {
+                return GestureDetector(
+                  onTap: onTap,
+                  child: AnimatedContainer(
+                    duration: const Duration(milliseconds: 200),
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 12, vertical: 6),
+                    decoration: BoxDecoration(
+                      color: isActive
+                          ? const Color(0xFF1F5DFF)
+                          : Colors.transparent,
+                      borderRadius: BorderRadius.circular(20),
+                      border: Border.all(
+                        color: isActive
+                            ? const Color(0xFF1F5DFF)
+                            : const Color(0xFF94A3B8),
+                      ),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          icon,
+                          size: 14,
+                          color: isActive
+                              ? Colors.white
+                              : const Color(0xFF64748B),
+                        ),
+                        const SizedBox(width: 6),
+                        Text(
+                          label,
+                          style: GoogleFonts.poppins(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w600,
+                            color: isActive
+                                ? Colors.white
+                                : const Color(0xFF64748B),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              }
+
+              return Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(18),
+                  border: Border.all(color: const Color(0xFFE5E7EB)),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Role',
+                      style: GoogleFonts.poppins(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w600,
+                        color: const Color(0xFF0F172A),
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    if (role == 'both') ...[
+                      Row(
+                        children: [
+                          _chip(
+                            'Driver',
+                            Icons.drive_eta,
+                            isActive: auth.activeMode == 'driver',
+                            onTap: () => auth.setActiveMode('driver'),
+                          ),
+                          const SizedBox(width: 8),
+                          _chip(
+                            'Passenger',
+                            Icons.person,
+                            isActive: auth.activeMode == 'passenger',
+                            onTap: () => auth.setActiveMode('passenger'),
+                          ),
+                        ],
+                      ),
+                    ] else if (role == 'driver') ...[
+                      _chip('Driver', Icons.drive_eta, isActive: true),
+                      const SizedBox(height: 8),
+                      TextButton.icon(
+                        onPressed: () => showUpgradeDialog(
+                          'Switching to Both mode allows you to create rides as a driver while also booking rides as a passenger.',
+                        ),
+                        icon: const Icon(Icons.person_outlined,
+                            size: 16, color: Color(0xFF1F5DFF)),
+                        label: Text(
+                          'Add passenger mode',
+                          style: GoogleFonts.poppins(
+                            fontSize: 13,
+                            fontWeight: FontWeight.w600,
+                            color: const Color(0xFF1F5DFF),
+                          ),
+                        ),
+                        style: TextButton.styleFrom(
+                          padding: EdgeInsets.zero,
+                          minimumSize: Size.zero,
+                          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                        ),
+                      ),
+                    ] else ...[
+                      _chip('Passenger', Icons.person, isActive: true),
+                      const SizedBox(height: 8),
+                      TextButton.icon(
+                        onPressed: () => showUpgradeDialog(
+                          'Switching to Both mode allows you to create rides as a driver while also booking rides as a passenger.',
+                        ),
+                        icon: const Icon(Icons.drive_eta_outlined,
+                            size: 16, color: Color(0xFF1F5DFF)),
+                        label: Text(
+                          'Add driver mode',
+                          style: GoogleFonts.poppins(
+                            fontSize: 13,
+                            fontWeight: FontWeight.w600,
+                            color: const Color(0xFF1F5DFF),
+                          ),
+                        ),
+                        style: TextButton.styleFrom(
+                          padding: EdgeInsets.zero,
+                          minimumSize: Size.zero,
+                          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              );
+            },
+          ),
 
           _SectionCard(
             title: 'Personal information',

--- a/lib/features/profile/profile_screen.dart
+++ b/lib/features/profile/profile_screen.dart
@@ -393,6 +393,76 @@ class ProfileScreen extends StatelessWidget {
               _InfoRow(label: 'Saved routes', value: '3'),
             ],
           ),
+
+          const SizedBox(height: 24),
+
+          SizedBox(
+            width: double.infinity,
+            height: 52,
+            child: OutlinedButton.icon(
+              icon: const Icon(Icons.logout, size: 18, color: Color(0xFFDC2626)),
+              label: Text(
+                'Log out',
+                style: GoogleFonts.poppins(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  color: const Color(0xFFDC2626),
+                ),
+              ),
+              onPressed: () async {
+                final confirmed = await showDialog<bool>(
+                  context: context,
+                  builder: (ctx) => AlertDialog(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(16),
+                    ),
+                    title: Text(
+                      'Log out',
+                      style: GoogleFonts.poppins(fontWeight: FontWeight.w600),
+                    ),
+                    content: Text(
+                      'Are you sure you want to log out?',
+                      style: GoogleFonts.poppins(
+                        fontSize: 14,
+                        color: const Color(0xFF64748B),
+                      ),
+                    ),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.of(ctx).pop(false),
+                        child: Text(
+                          'Cancel',
+                          style: GoogleFonts.poppins(
+                            color: const Color(0xFF64748B),
+                          ),
+                        ),
+                      ),
+                      TextButton(
+                        onPressed: () => Navigator.of(ctx).pop(true),
+                        child: Text(
+                          'Log out',
+                          style: GoogleFonts.poppins(
+                            color: const Color(0xFFDC2626),
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+                if ((confirmed ?? false) && context.mounted) {
+                  await context.read<AuthViewModel>().signOut();
+                  if (context.mounted) context.go('/');
+                }
+              },
+              style: OutlinedButton.styleFrom(
+                side: const BorderSide(color: Color(0xFFDC2626)),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+            ),
+          ),
         ],
       ),
       bottomNavigationBar: const UniRideBottomNav(currentIndex: 4),

--- a/lib/features/rides/available_rides_screen.dart
+++ b/lib/features/rides/available_rides_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:cloud_functions/cloud_functions.dart';
 import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:go_router/go_router.dart';
@@ -608,7 +609,7 @@ class _FilterChip extends StatelessWidget {
   }
 }
 
-class _RideCard extends StatelessWidget {
+class _RideCard extends StatefulWidget {
   const _RideCard({
     required this.ride,
     required this.rank,
@@ -620,7 +621,80 @@ class _RideCard extends StatelessWidget {
   final bool isBestMatch;
 
   @override
+  State<_RideCard> createState() => _RideCardState();
+}
+
+class _RideCardState extends State<_RideCard> {
+  bool _isRequesting = false;
+
+  Future<void> _onReserve() async {
+    setState(() => _isRequesting = true);
+    try {
+      await FirebaseFunctions.instance
+          .httpsCallable('requestRide')
+          .call({'rideId': widget.ride.id});
+
+      if (mounted) {
+        context
+            .read<RideViewModel>()
+            .requestedRideIds
+            .add(widget.ride.id);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'Request sent to ${widget.ride.driverName}!',
+              style: GoogleFonts.poppins(color: Colors.white),
+            ),
+            backgroundColor: _RidesColors.primary,
+            duration: const Duration(seconds: 3),
+            behavior: SnackBarBehavior.floating,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+            ),
+          ),
+        );
+      }
+    } on FirebaseFunctionsException catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              e.message ?? 'Could not send request. Try again.',
+              style: GoogleFonts.poppins(color: Colors.white),
+            ),
+            backgroundColor: Colors.red,
+            behavior: SnackBarBehavior.floating,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+            ),
+          ),
+        );
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'Unexpected error. Try again.',
+              style: GoogleFonts.poppins(color: Colors.white),
+            ),
+            backgroundColor: Colors.red,
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isRequesting = false);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final ride = widget.ride;
+    final rank = widget.rank;
+    final isBestMatch = widget.isBestMatch;
+    final alreadyRequested =
+        context.watch<RideViewModel>().requestedRideIds.contains(ride.id);
     final String timeStr = _fmtTime(ride.departureTime);
     final String priceStr = _fmtPrice(ride.price);
 
@@ -887,43 +961,66 @@ class _RideCard extends StatelessWidget {
                     ],
                   ),
                 ),
-                SizedBox(
-                  width: 100,
-                  height: 40,
-                  child: ElevatedButton(
-                    onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text(
-                          'Ride reserved with ${ride.driverName}!',
-                          style: GoogleFonts.poppins(color: Colors.white),
+                if (alreadyRequested)
+                  Container(
+                    height: 40,
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
+                    decoration: BoxDecoration(
+                      color: const Color(0xFFF0FDF4),
+                      borderRadius: BorderRadius.circular(10),
+                      border: Border.all(color: const Color(0xFF86EFAC)),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const Icon(Icons.check_circle,
+                            size: 14, color: Color(0xFF16A34A)),
+                        const SizedBox(width: 4),
+                        Text(
+                          'Solicitado',
+                          style: GoogleFonts.poppins(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w600,
+                            color: const Color(0xFF16A34A),
+                          ),
                         ),
+                      ],
+                    ),
+                  )
+                else
+                  SizedBox(
+                    width: 100,
+                    height: 40,
+                    child: ElevatedButton(
+                      onPressed: _isRequesting ? null : _onReserve,
+                      style: ElevatedButton.styleFrom(
                         backgroundColor: _RidesColors.primary,
-                        duration: const Duration(seconds: 2),
-                        behavior: SnackBarBehavior.floating,
+                        foregroundColor: Colors.white,
+                        padding: EdgeInsets.zero,
+                        elevation: 0,
                         shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(8),
+                          borderRadius: BorderRadius.circular(10),
                         ),
                       ),
-                    ),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: _RidesColors.primary,
-                      foregroundColor: Colors.white,
-                      padding: EdgeInsets.zero,
-                      elevation: 0,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(10),
-                      ),
-                    ),
-                    child: Text(
-                      'Reserve',
-                      style: GoogleFonts.poppins(
-                        fontSize: 14,
-                        fontWeight: FontWeight.w600,
-                        color: Colors.white,
-                      ),
+                      child: _isRequesting
+                          ? const SizedBox(
+                              width: 18,
+                              height: 18,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                color: Colors.white,
+                              ),
+                            )
+                          : Text(
+                              'Reserve',
+                              style: GoogleFonts.poppins(
+                                fontSize: 14,
+                                fontWeight: FontWeight.w600,
+                                color: Colors.white,
+                              ),
+                            ),
                     ),
                   ),
-                ),
               ],
             ),
           ],

--- a/lib/features/rides/ride_viewmodel.dart
+++ b/lib/features/rides/ride_viewmodel.dart
@@ -5,17 +5,23 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 
 import '../../core/connectivity/connectivity_service.dart';
+import '../../core/db/daos/ride_dao.dart';
+import '../../core/db/database_helper.dart';
 import '../../data/models/ride_model.dart';
 import '../../data/repositories/impl/firebase_ride_repository.dart';
 import '../../data/repositories/ride_repository.dart';
 
 class RideViewModel extends ChangeNotifier {
   RideViewModel(this._repository) {
+    _dao = RideDao(DatabaseHelper());
     _setupConnectivityListener();
   }
 
   final RideRepository _repository;
+  late final RideDao _dao;
+
   StreamSubscription<bool>? _connectivitySub;
+  StreamSubscription<QuerySnapshot>? _ridesSub;
 
   List<RideModel> _rides = [];
   bool _isLoading = false;
@@ -38,54 +44,73 @@ class RideViewModel extends ChangeNotifier {
 
   void _setupConnectivityListener() {
     _connectivitySub = ConnectivityService().onStatusChanged.listen((isOnline) {
-      final wasOffline = isOffline;
-
       isOffline = !isOnline;
       notifyListeners();
-
-      if (isOnline && (wasOffline || isFromCache)) {
-        debugPrint('[RideVM] back online — reloading rides');
-        invalidateAndReload();
+      if (isOnline && isFromCache) {
+        // Reconnected — re-subscribe to get live data
+        loadAvailableRides();
       }
     });
   }
 
   @override
   void dispose() {
+    _ridesSub?.cancel();
     _connectivitySub?.cancel();
     super.dispose();
   }
 
-  Future<void> loadAvailableRides() async {
+  /// Subscribes to a real-time Firestore stream of available rides.
+  /// The UI updates automatically whenever rides are added, modified or removed.
+  void loadAvailableRides() {
+    _ridesSub?.cancel();
     _isLoading = true;
     _isSearchMode = false;
     _errorMessage = null;
     notifyListeners();
 
-    try {
-      final repo = _repository;
+    _ridesSub = FirebaseFirestore.instance
+        .collection('rides')
+        .where('status', whereIn: ['available', 'active'])
+        .snapshots()
+        .listen(
+      (snap) {
+        final now = DateTime.now();
+        _rides = snap.docs
+            .map((d) => RideModel.fromMap(d.data(), d.id))
+            .where((r) => r.departureTime.isAfter(now))
+            .toList()
+          ..sort((a, b) => a.departureTime.compareTo(b.departureTime));
 
-      if (repo is FirebaseRideRepository) {
-        _rides = await repo.getAvailableRidesWithFallback(
-          onCacheStatus: (fromCache) {
-            isFromCache = fromCache;
-            isOffline = fromCache;
-            debugPrint('[RideVM] isFromCache set to $fromCache');
-          },
-        );
-      } else {
-        _rides = await _repository.getAvailableRides();
         isFromCache = false;
         isOffline = false;
-      }
-    } catch (e) {
-      _errorMessage = e.toString().replaceFirst('Exception: ', '');
-    }
+        _isLoading = false;
+        _errorMessage = null;
 
-    await _loadRequestedRideIds();
+        // Notify immediately so the spinner stops and rides show up
+        notifyListeners();
 
-    _isLoading = false;
-    notifyListeners();
+        // Update SQLite cache and requested-ride badges in background
+        unawaited(_dao.insertOrReplaceAll(_rides));
+        unawaited(_loadRequestedRideIds().then((_) => notifyListeners()));
+      },
+      onError: (e) {
+        debugPrint('[RideVM] stream error: $e — falling back to SQLite');
+        _dao.fetchAll().then((cached) {
+          final now = DateTime.now();
+          _rides = cached
+              .where((r) => r.departureTime.isAfter(now))
+              .toList()
+            ..sort((a, b) => a.departureTime.compareTo(b.departureTime));
+          isFromCache = _rides.isNotEmpty;
+          isOffline = true;
+          _isLoading = false;
+          _errorMessage = _rides.isEmpty ? 'No rides available offline.' : null;
+          notifyListeners();
+          unawaited(_loadRequestedRideIds().then((_) => notifyListeners()));
+        });
+      },
+    );
   }
 
   Future<void> _loadRequestedRideIds() async {
@@ -103,25 +128,13 @@ class RideViewModel extends ChangeNotifier {
     }
   }
 
-  Future<void> invalidateAndReload() async {
-    debugPrint('[RideVM] invalidateAndReload started');
-
-    final repo = _repository;
-    if (repo is FirebaseRideRepository) {
-      repo.invalidateRideCache();
-    }
-
-    await loadAvailableRides();
-
-    debugPrint('[RideVM] invalidateAndReload done, isFromCache=$isFromCache');
-  }
-
   void setSearchTerms(String origin, String destination) {
     _searchOrigin = origin;
     _searchDestination = destination;
   }
 
   Future<void> loadMatchingRides(String userId) async {
+    _ridesSub?.cancel(); // stop live updates while in search mode
     _isLoading = true;
     _isSearchMode = true;
     _errorMessage = null;
@@ -139,6 +152,15 @@ class RideViewModel extends ChangeNotifier {
 
   Future<void> reserveRide(String rideId, String userId) async {
     await _repository.reserveRide(rideId, userId);
-    await loadAvailableRides();
+    // Stream will pick up seat count change automatically — no manual reload needed
+  }
+
+  /// Kept for backward compatibility — callers can still use this to force
+  /// a fresh subscription (e.g. after coming back online).
+  Future<void> invalidateAndReload() async {
+    if (_repository is FirebaseRideRepository) {
+      (_repository as FirebaseRideRepository).invalidateRideCache();
+    }
+    loadAvailableRides();
   }
 }

--- a/lib/features/rides/ride_viewmodel.dart
+++ b/lib/features/rides/ride_viewmodel.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 
 import '../../core/connectivity/connectivity_service.dart';
@@ -25,6 +27,7 @@ class RideViewModel extends ChangeNotifier {
 
   bool isFromCache = false;
   bool isOffline = false;
+  Set<String> requestedRideIds = {};
 
   List<RideModel> get rides => _rides;
   bool get isLoading => _isLoading;
@@ -79,8 +82,25 @@ class RideViewModel extends ChangeNotifier {
       _errorMessage = e.toString().replaceFirst('Exception: ', '');
     }
 
+    await _loadRequestedRideIds();
+
     _isLoading = false;
     notifyListeners();
+  }
+
+  Future<void> _loadRequestedRideIds() async {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) return;
+    try {
+      final snap = await FirebaseFirestore.instance
+          .collection('rideRequests')
+          .where('passengerId', isEqualTo: uid)
+          .where('status', whereIn: ['pending', 'accepted'])
+          .get();
+      requestedRideIds = snap.docs.map((d) => d['rideId'] as String).toSet();
+    } catch (e) {
+      debugPrint('[RideVM] failed to load requested rides: $e');
+    }
   }
 
   Future<void> invalidateAndReload() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'features/auth/auth_viewmodel.dart';
 import 'features/chatbot/data/chatbot_service.dart';
 import 'features/chatbot/state/chatbot_controller.dart';
 import 'features/home/weather_viewmodel.dart';
+import 'features/notifications/notifications_viewmodel.dart';
 import 'features/rides/ride_viewmodel.dart';
 import 'firebase_options.dart';
 
@@ -60,6 +61,9 @@ class UniRideBootstrap extends StatelessWidget {
         ),
         ChangeNotifierProvider(
           create: (_) => WeatherViewModel(OpenMeteoRepository()),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => NotificationsViewModel(),
         ),
       ],
       child: const UniRideApp(),

--- a/lib/shared/widgets/bottom_nav_bar.dart
+++ b/lib/shared/widgets/bottom_nav_bar.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:provider/provider.dart';
+import 'package:uniride/features/auth/auth_viewmodel.dart';
 
 abstract final class _NavColors {
   static const selected = Color(0xFF1F5DFF);
@@ -28,7 +30,14 @@ class UniRideBottomNav extends StatelessWidget {
       unselectedLabelStyle: GoogleFonts.poppins(fontSize: 11),
       onTap: (index) {
         if (index == 0) context.go('/home');
-        if (index == 1) context.go('/rides');
+        if (index == 1) {
+          final authVm = context.read<AuthViewModel>();
+          final role = authVm.currentUser?.role ?? 'passenger';
+          final activeMode = authVm.activeMode;
+          final isDriverMode = role == 'driver' ||
+              (role == 'both' && activeMode == 'driver');
+          context.go(isDriverMode ? '/driver/my-rides' : '/rides');
+        }
         if (index == 2) context.go('/bookings');
         if (index == 3) context.go('/community');
         if (index == 4) context.go('/profile');


### PR DESCRIPTION
## Driver screens — complete driver flow

Implements the full driver navigation flow for the
UniRide Flutter app.

### Changes

**Role infrastructure**
- HomeScreen: role badge chip (Driver mode / Passenger mode)
- HomeScreen: "+" FAB to create a ride (driver only)
- HomeScreen: active ride banner when driver has
  an in_progress ride
- ProfileScreen: role switcher for users with role='both'
- Rides tab: role-aware routing (driver → My Rides,
  passenger → Available Rides)
- Placeholder driver routes added to go_router

**CreateRideScreen** (`/driver/create-ride`)
- Form: origin, destination, zone picker, departure
  time, seats stepper, price in COP
- Calls `createRide` Cloud Function
- Offline: SyncManager.enqueue('create_ride')

**MyRidesScreen** (`/driver/my-rides`)
- Lists rides filtered by driverId from Firestore
- SQLite fallback offline + OfflineBanner
- Pending rides show orange badge
- Navigation to RideRequests and ActiveRide per ride

**RideRequestsScreen** (`/driver/ride-requests`)
- Lists pending rideRequests for a given rideId
- Accept/Reject disabled offline (requires live seat count)

**AcceptRejectSheet**
- Bottom sheet popup for accept/reject confirmation
- Calls `acceptRide` / `rejectRide` Cloud Functions
- No write queue by design (seat count is live data)

**ActiveRideScreen** (`/driver/active-ride`) — placeholder
- Passenger list from Firestore (accepted requests)
- Map section marked "coming soon"
- Finish Ride button calls `finishRide` CF

### Closes
#38 
#39 
#40 
#41  
#42 